### PR TITLE
Convert spaces to tabs and extract MavenProjectBuilder test class to its own file

### DIFF
--- a/src/main/java/com/mfoot/mojo/libyear/LibYearMojo.java
+++ b/src/main/java/com/mfoot/mojo/libyear/LibYearMojo.java
@@ -97,8 +97,8 @@ public class LibYearMojo extends AbstractMojo {
 	protected Settings settings;
 
 	// TODO: Add test coverage for this before exposing it as an option
-//	@Parameter(property = "maven.version.ignore")
-//	protected Set<String> ignoredVersions;
+	//	@Parameter(property = "maven.version.ignore")
+	//	protected Set<String> ignoredVersions;
 	private final Set<String> ignoredVersions = new HashSet<>();
 
 	@Parameter(defaultValue = "${session}", required = true, readonly = true)
@@ -157,9 +157,7 @@ public class LibYearMojo extends AbstractMojo {
 	// private boolean processDependencyManagementTransitive;
 	private final boolean processDependencyManagementTransitive = false;
 
-	// TODO: Add test coverage for this before exposing it as an option
-	//	@Parameter(property = "processDependencyManagement", defaultValue = "true")
-	//	private boolean processDependencyManagement;
+	@Parameter(property = "processDependencyManagement", defaultValue = "true")
 	private final boolean processDependencyManagement = true;
 
 	// TODO: Add test coverage for this before exposing it as an option

--- a/src/test/java/com/mfoot/mojo/libyear/InMemoryTestLogger.java
+++ b/src/test/java/com/mfoot/mojo/libyear/InMemoryTestLogger.java
@@ -23,87 +23,88 @@ import java.util.List;
 
 class InMemoryTestLogger implements Log {
 
-    public final List<String> infoLogs = new ArrayList<>();
-    public final List<String> errorLogs = new ArrayList<>();
-    public final List<String> debugLogs = new ArrayList<>();
+	public final List<String> infoLogs = new ArrayList<>();
+	public final List<String> errorLogs = new ArrayList<>();
+	public final List<String> debugLogs = new ArrayList<>();
 
-    @Override
-    public boolean isDebugEnabled() {
-        return true;
-    }
+	@Override
+	public boolean isDebugEnabled() {
+		return true;
+	}
 
-    @Override
-    public void debug(CharSequence charSequence) {
-        debugLogs.add(charSequence.toString());
-    }
+	@Override
+	public void debug(CharSequence charSequence) {
+		System.out.println(charSequence);
+		debugLogs.add(charSequence.toString());
+	}
 
-    @Override
-    public void debug(CharSequence charSequence, Throwable throwable) {
+	@Override
+	public void debug(CharSequence charSequence, Throwable throwable) {
 
-    }
+	}
 
-    @Override
-    public void debug(Throwable throwable) {
+	@Override
+	public void debug(Throwable throwable) {
 
-    }
+	}
 
-    @Override
-    public boolean isInfoEnabled() {
-        return false;
-    }
+	@Override
+	public boolean isInfoEnabled() {
+		return false;
+	}
 
-    @Override
-    public void info(CharSequence charSequence) {
-        infoLogs.add(charSequence.toString());
-    }
+	@Override
+	public void info(CharSequence charSequence) {
+		infoLogs.add(charSequence.toString());
+	}
 
-    @Override
-    public void info(CharSequence charSequence, Throwable throwable) {
+	@Override
+	public void info(CharSequence charSequence, Throwable throwable) {
 
-    }
+	}
 
-    @Override
-    public void info(Throwable throwable) {
+	@Override
+	public void info(Throwable throwable) {
 
-    }
+	}
 
-    @Override
-    public boolean isWarnEnabled() {
-        return false;
-    }
+	@Override
+	public boolean isWarnEnabled() {
+		return false;
+	}
 
-    @Override
-    public void warn(CharSequence charSequence) {
+	@Override
+	public void warn(CharSequence charSequence) {
 
-    }
+	}
 
-    @Override
-    public void warn(CharSequence charSequence, Throwable throwable) {
+	@Override
+	public void warn(CharSequence charSequence, Throwable throwable) {
 
-    }
+	}
 
-    @Override
-    public void warn(Throwable throwable) {
+	@Override
+	public void warn(Throwable throwable) {
 
-    }
+	}
 
-    @Override
-    public boolean isErrorEnabled() {
-        return false;
-    }
+	@Override
+	public boolean isErrorEnabled() {
+		return false;
+	}
 
-    @Override
-    public void error(CharSequence charSequence) {
-        errorLogs.add(charSequence.toString());
-    }
+	@Override
+	public void error(CharSequence charSequence) {
+		errorLogs.add(charSequence.toString());
+	}
 
-    @Override
-    public void error(CharSequence charSequence, Throwable throwable) {
+	@Override
+	public void error(CharSequence charSequence, Throwable throwable) {
 
-    }
+	}
 
-    @Override
-    public void error(Throwable throwable) {
+	@Override
+	public void error(Throwable throwable) {
 
-    }
+	}
 }

--- a/src/test/java/com/mfoot/mojo/libyear/LibYearMojoTest.java
+++ b/src/test/java/com/mfoot/mojo/libyear/LibYearMojoTest.java
@@ -17,13 +17,8 @@
 package com.mfoot.mojo.libyear;
 
 import com.github.tomakehurst.wiremock.junit5.WireMockTest;
-import org.apache.maven.model.Build;
 import org.apache.maven.model.Dependency;
-import org.apache.maven.model.DependencyManagement;
-import org.apache.maven.model.Model;
 import org.apache.maven.model.Plugin;
-import org.apache.maven.model.PluginManagement;
-import org.apache.maven.project.MavenProject;
 import org.codehaus.mojo.versions.filtering.WildcardMatcher;
 import org.codehaus.mojo.versions.utils.DependencyBuilder;
 import org.json.JSONArray;
@@ -37,9 +32,7 @@ import org.mockito.quality.Strictness;
 
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
-import java.util.Collections;
 import java.util.HashMap;
-import java.util.List;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
@@ -68,563 +61,572 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 @WireMockTest(httpPort = 8080)
 public class LibYearMojoTest {
 
-    // TODO: Wildcard exclude, e.g. com.mfoot.*
-    // TODO: Tests with version numbers being referenced by variables
-    // TODO: Test with version ranges
-    // TODO: Cleanup
-    // TODO: Run code formatter via plugin and enforce format
-    // TODO: This file is using spaces, not tabs
-
-    private static Plugin pluginOf(String artifactId, String groupId, String version) {
-        Plugin plugin = new Plugin();
-        plugin.setGroupId(groupId);
-        plugin.setArtifactId(artifactId);
-        plugin.setVersion(version);
-        return plugin;
-    }
-
-    @AfterEach
-    public void reset() {
-        // TODO: Make these private and add a reset method in the mojo
-        LibYearMojo.libWeeksOutDated.set(0);
-        LibYearMojo.dependencyVersionReleaseDates.clear();
-        LibYearMojo.readyProjectsCounter.set(0);
-    }
-
-    @Test
-    public void dependencyUpdateAvailable() throws Exception {
-        LibYearMojo mojo = new LibYearMojo(mockRepositorySystem(), mockAetherRepositorySystem(new HashMap<>() {{
-            put("default-dependency", new String[]{"1.0.0", "1.1.0", "2.0.0"});
-        }})
-
-        ) {{
-            setProject(new MavenProjectBuilder().withDependencies(singletonList(DependencyBuilder.newBuilder().withGroupId("default-group").withArtifactId("default-dependency").withVersion("1.0.0").build())).build());
-            allowProcessingAllDependencies(this);
-            setPluginContext(new HashMap<>());
-
-            session = mockMavenSession();
-            SEARCH_URI = "http://localhost:8080";
-
-            setLog(new InMemoryTestLogger());
-        }};
-
-        LocalDateTime now = LocalDateTime.now();
-
-        // Mark version 2.0.0 as a year newer
-        // Don't stub 1.1.0, there's no need to check its version
-        stubResponseFor("default-group", "default-dependency", "1.0.0", now.minusYears(1));
-        stubResponseFor("default-group", "default-dependency", "2.0.0", now);
-
-        mojo.execute();
-
-        assertTrue(((InMemoryTestLogger) mojo.getLog()).infoLogs.stream().anyMatch((l) ->
-                l.contains("default-group:default-dependency") && l.contains("1.00 libyears")));
-        assertTrue(((InMemoryTestLogger) mojo.getLog()).errorLogs.isEmpty());
-    }
-
-    @Test
-    public void dependencyUpdateWithLongNameAvailable() throws Exception {
-        LibYearMojo mojo = new LibYearMojo(mockRepositorySystem(), mockAetherRepositorySystem(new HashMap<>() {{
-            put("default-dependency-with-very-very-long-name", new String[]{"1.0.0", "1.1.0", "2.0.0"});
-        }})
-
-        ) {{
-            setProject(new MavenProjectBuilder().withDependencies(singletonList(DependencyBuilder
-                    .newBuilder().withGroupId("default-group")
-                    .withArtifactId("default-dependency-with-very-very-long-name").withVersion("1.0.0").build())).build());
-            allowProcessingAllDependencies(this);
-            setPluginContext(new HashMap<>());
-
-            session = mockMavenSession();
-            SEARCH_URI = "http://localhost:8080";
-
-            setLog(new InMemoryTestLogger());
-        }};
-
-        LocalDateTime now = LocalDateTime.now();
-
-        // Mark version 2.0.0 as a year newer
-        stubResponseFor("default-group", "default-dependency-with-very-very-long-name", "1.0.0", now.minusYears(1));
-        stubResponseFor("default-group", "default-dependency-with-very-very-long-name", "2.0.0", now);
-
-        mojo.execute();
-
-        // TODO: Implement wrapping for libyear output for dependencies with long names then update this test
-        assertTrue(((InMemoryTestLogger) mojo.getLog()).infoLogs.stream().anyMatch((l) ->
-                l.contains("default-group:default-dependency-with-very-very-long-name") && l.contains("1.00 libyears")));
-        assertTrue(((InMemoryTestLogger) mojo.getLog()).errorLogs.isEmpty());
-    }
-
-    @Test
-    public void cacheIsUsedForDependencyVersions() throws Exception {
-        // Run one of the tests twice, which should only trigger one fetch per dependency version
-        dependencyUpdateAvailable();
-        dependencyUpdateAvailable();
-
-        // One call for v1.0.0
-        verify(1,
-                getRequestedFor(urlPathEqualTo("/solrsearch/select"))
-                        .withQueryParam("q", equalTo("g:default-group AND a:default-dependency AND v:1.0.0")));
-
-        // One call for v2.0.0
-        verify(1, getRequestedFor(urlPathEqualTo("/solrsearch/select"))
-                .withQueryParam("q", equalTo("g:default-group AND a:default-dependency AND v:2.0.0")));
-    }
-
-    @Test
-    public void dependencyUpdateAvailableWhenVersionSpecifiedInDependencyManagement() throws Exception {
-        LibYearMojo mojo = new LibYearMojo(mockRepositorySystem(), mockAetherRepositorySystem(new HashMap<>() {{
-            put("default-dependency", new String[]{"1.0.0", "1.1.0", "2.0.0"});
-        }})
-
-        ) {{
-            setProject(new MavenProjectBuilder()
-                    .withDependencies(singletonList(DependencyBuilder.newBuilder()
-                            .withGroupId("default-group")
-                            .withArtifactId("default-dependency")
-                            .withVersion("1.0.0") // This is overridden by dependencyManagement
-                    .build()))
-                    .withDependencyManagementDependencyList(
-                            singletonList(DependencyBuilder.newBuilder()
-                                    .withGroupId("default-group")
-                                    .withArtifactId("default-dependency")
-                                    .withVersion("1.1.0").build()))
-                    .build());
-            allowProcessingAllDependencies(this);
-            setPluginContext(new HashMap<>());
-
-            session = mockMavenSession();
-            SEARCH_URI = "http://localhost:8080";
-
-            setLog(new InMemoryTestLogger());
-        }};
-
-        LocalDateTime now = LocalDateTime.now();
-
-        // Mark version 2.0.0 as a year newer than the version specified by dependencyManagement
-        stubResponseFor("default-group", "default-dependency", "1.0.0", now.minusYears(2));
-        stubResponseFor("default-group", "default-dependency", "1.1.0", now.minusYears(1));
-        stubResponseFor("default-group", "default-dependency", "2.0.0", now);
-
-        mojo.execute();
-
-        assertTrue(((InMemoryTestLogger) mojo.getLog()).infoLogs.stream().anyMatch((l) -> l.contains("default-group:default-dependency") && l.contains("1.00 libyears")));
-
-        assertTrue(((InMemoryTestLogger) mojo.getLog()).errorLogs.isEmpty());
-    }
-
-    /**
-     * This test has a dependency with version 1.0.0, which is overridden by
-     * dependencyManagement to 1.1.0. Version 2.0.0 is available.
-     * <p>
-     * We ensure that the proposed change is the libyears between 1.1.0 and
-     * 2.0.0.
-     */
-    @Test
-    public void dependencyUpdateAvailableDependencyDefinedInDependencyManagement() throws Exception {
-        LibYearMojo mojo = new LibYearMojo(mockRepositorySystem(), mockAetherRepositorySystem(new HashMap<>() {{
-            put("default-dependency", new String[]{"1.0.0", "1.1.0", "2.0.0"});
-        }})
-
-        ) {{
-            setProject(new MavenProjectBuilder().withDependencies(
-                    singletonList(DependencyBuilder.newBuilder()
-                            .withGroupId("default-group")
-                            .withArtifactId("default-dependency")
-                            .withVersion("1.0.0")
-                            .build()))
-                    .withDependencyManagementDependencyList(singletonList(DependencyBuilder.newBuilder()
-                            .withGroupId("default-group")
-                            .withArtifactId("default-dependency")
-                            .withVersion("1.1.0")
-                            .build()))
-                    .build());
-            allowProcessingAllDependencies(this);
-            setPluginContext(new HashMap<>());
-
-            session = mockMavenSession();
-            SEARCH_URI = "http://localhost:8080";
-
-            setLog(new InMemoryTestLogger());
-        }};
-
-        LocalDateTime now = LocalDateTime.now();
-
-        // Mark version 2.0.0 as a year newer. The current dependency version is 1.1.0, overridden from 1.0.0 by
-        // dependencyManagement
-
-        // TODO: This first stub probably shouldn't be needed as we shouldn't need to fetch the release year of this version
-        // but without it, the test fails.
-        stubResponseFor("default-group", "default-dependency", "1.0.0", now.minusYears(10));
-        stubResponseFor("default-group", "default-dependency", "1.1.0", now.minusYears(1));
-        stubResponseFor("default-group", "default-dependency", "2.0.0", now);
-
-        mojo.execute();
-
-        assertTrue(((InMemoryTestLogger) mojo.getLog()).infoLogs.stream().anyMatch(
-                (l) -> l.contains("default-group:default-dependency") && l.contains("1.00 libyears")));
-        assertTrue(((InMemoryTestLogger) mojo.getLog()).errorLogs.isEmpty());
-    }
-
-    @Test
-    public void pluginVersionUpdateAvailable() throws Exception {
-        Plugin plugin = pluginOf("default-plugin", "default-group", "1.0.0");
-        plugin.setDependencies(singletonList(dependencyFor("default-group", "default-dependency", "1.0.0")));
-
-        LibYearMojo mojo = new LibYearMojo(mockRepositorySystem(), mockAetherRepositorySystem(new HashMap<>() {{
-            put("default-dependency", new String[]{"1.0.0", "1.1.0", "2.0.0"});
-        }})
-
-        ) {{
-            setProject(new MavenProjectBuilder().withPlugins(singletonList(plugin)).build());
-
-            allowProcessingAllDependencies(this);
-            setPluginContext(new HashMap<>());
-
-            session = mockMavenSession();
-            SEARCH_URI = "http://localhost:8080";
-
-            setLog(new InMemoryTestLogger());
-        }};
-
-        LocalDateTime now = LocalDateTime.now();
-
-        // Mark version 2.0.0 as a year newer
-        stubResponseFor("default-group", "default-dependency", "1.0.0", now.minusYears(1));
-        stubResponseFor("default-group", "default-dependency", "2.0.0", now);
-
-        mojo.execute();
-
-        assertTrue(((InMemoryTestLogger) mojo.getLog()).infoLogs.stream().anyMatch((l) ->
-                l.contains("default-group:default-dependency") && l.contains("1.00 libyears")));
-        assertTrue(((InMemoryTestLogger) mojo.getLog()).errorLogs.isEmpty());
-    }
-
-    /**
-     * This test has a plugin version 1.0.0 which has a dependency on another
-     * artifact version 1.0.1. That version is overridden in dependency management
-     * to 1.1.0. Version 2.0.0 is available.
-     * <p>
-     * This test ensures we suggest the libyears between 1.1.0 and 2.0.0.
-     */
-    @Test
-    public void pluginVersionUpdateAvailableDependencyDefinedInDependencyManagement() throws Exception {
-        Plugin plugin = pluginOf("default-plugin", "default-group", "1.0.0");
-        plugin.setDependencies(singletonList(dependencyFor("default-group", "default-dependency", "1.0.1")));
-
-        LibYearMojo mojo = new LibYearMojo(mockRepositorySystem(), mockAetherRepositorySystem(new HashMap<>() {{
-            put("default-dependency", new String[]{"1.0.0", "1.1.0", "2.0.0"});
-        }})
-
-        ) {{
-            setProject(new MavenProjectBuilder().withPlugins(singletonList(plugin)).withDependencyManagementDependencyList(singletonList(DependencyBuilder.newBuilder().withGroupId("default-group").withArtifactId("default-dependency").withVersion("1.1.0").build())).build());
-
-            allowProcessingAllDependencies(this);
-            setPluginContext(new HashMap<>());
-
-            session = mockMavenSession();
-            SEARCH_URI = "http://localhost:8080";
-
-            setLog(new InMemoryTestLogger());
-        }};
-
-        LocalDateTime now = LocalDateTime.now();
-
-        // Mark version 2.0.0 as a year newer
-        stubResponseFor("default-group", "default-dependency", "1.0.1", now.minusYears(2));
-        stubResponseFor("default-group", "default-dependency", "1.1.0", now.minusYears(1));
-        stubResponseFor("default-group", "default-dependency", "2.0.0", now);
-
-        mojo.execute();
-
-        assertTrue(((InMemoryTestLogger) mojo.getLog()).infoLogs.stream().anyMatch((l) ->
-                l.contains("default-group:default-dependency") && l.contains("1.00 libyears")));
-        assertTrue(((InMemoryTestLogger) mojo.getLog()).errorLogs.isEmpty());
-    }
-
-    /**
-     * This test has a plugin version 1.0.0. That version is overridden in plugin management to 1.1.0.
-     * Version 2.0.0 is available.
-     * <p>
-     * This test ensures we suggest the libyears between 1.1.0 and 2.0.0.
-     */
-    @Test
-    public void pluginVersionUpdateAvailableDependencyDefinedInPluginManagement() throws Exception {
-        Plugin plugin = pluginOf("default-plugin", "default-group", "1.0.0");
-        plugin.setDependencies(singletonList(dependencyFor("default-group", "default-dependency", "1.0.1")));
-
-        Plugin managedPlugin = pluginOf("default-plugin", "default-group", "1.0.0");
-        plugin.setDependencies(singletonList(dependencyFor("default-group", "default-dependency", "1.1.0")));
-
-        LibYearMojo mojo = new LibYearMojo(mockRepositorySystem(), mockAetherRepositorySystem(new HashMap<>() {{
-            put("default-dependency", new String[]{"1.0.0", "1.1.0", "2.0.0"});
-        }})
-
-        ) {{
-            setProject(new MavenProjectBuilder()
-                    .withPlugins(singletonList(plugin))
-                    .withPluginManagementPluginList(singletonList(managedPlugin)).build());
-
-            allowProcessingAllDependencies(this);
-
-            setPluginContext(new HashMap<>());
-
-            session = mockMavenSession();
-            SEARCH_URI = "http://localhost:8080";
-
-            setLog(new InMemoryTestLogger());
-        }};
-
-        LocalDateTime now = LocalDateTime.now();
-
-        // Mark version 2.0.0 as a year newer
-        stubResponseFor("default-group", "default-dependency", "1.1.0", now.minusYears(1));
-        stubResponseFor("default-group", "default-dependency", "2.0.0", now);
-
-        mojo.execute();
-
-        assertTrue(((InMemoryTestLogger) mojo.getLog()).infoLogs.stream().anyMatch((l) -> l.contains("default-group:default-dependency") && l.contains("1.00 libyears")));
-        assertTrue(((InMemoryTestLogger) mojo.getLog()).errorLogs.isEmpty());
-    }
-
-    private Dependency dependencyFor(String groupID, String artifactId, String version) {
-        Dependency dep = new Dependency();
-        dep.setGroupId(groupID);
-        dep.setArtifactId(artifactId);
-        dep.setVersion(version);
-        return dep;
-    }
-
-    /**
-     * Stub the Maven search API response that looks for release information for a particular version of a particular
-     * artifact
-     */
-    private void stubResponseFor(String groupId, String artifactId, String version, LocalDateTime time) {
-        stubFor(get(urlPathEqualTo("/solrsearch/select")).withQueryParam("q", equalTo(String.format("g:%s AND a:%s AND v:%s", groupId, artifactId, version))).withQueryParam("wt", equalTo("json")).willReturn(ok(getJSONResponseForVersion(groupId, artifactId, version, time))));
-    }
-
-    /**
-     * Simulate the JSON response from the Maven Central repository search API. Docs available at
-     * <a href="https://central.sonatype.org/search/rest-api-guide/">here</a>.
-     */
-    private String getJSONResponseForVersion(String groupId, String artifactId, String version, LocalDateTime releaseDate) {
-        JSONObject root = new JSONObject();
-        JSONObject response = new JSONObject();
-        JSONArray versions = new JSONArray();
-        JSONObject newVersion = new JSONObject();
-
-        newVersion.put("id", String.format("%s:%s:%s", groupId, artifactId, version));
-        newVersion.put("g", groupId);
-        newVersion.put("a", artifactId);
-        newVersion.put("v", version);
-        newVersion.put("p", "jar");
-        newVersion.put("timestamp", releaseDate.toEpochSecond(ZoneOffset.UTC) * 1000); // API response is in millis
-
-        versions.put(newVersion);
-        response.put("docs", versions);
-        response.put("numFound", 1);
-        root.put("response", response);
-
-        return root.toString();
-    }
-
-    @Test
-    public void apiCallToMavenFails() throws Exception {
-        LibYearMojo mojo = new LibYearMojo(mockRepositorySystem(), mockAetherRepositorySystem(new HashMap<>() {{
-            put("default-dependency", new String[]{"1.0.0", "2.0.0"});
-        }})) {{
-            setProject(new MavenProjectBuilder().withDependencies(singletonList(DependencyBuilder.newBuilder()
-                    .withGroupId("default-group")
-                    .withArtifactId("default-dependency")
-                    .withVersion("1.0.0").build()))
-                .build());
-            allowProcessingAllDependencies(this);
-            setPluginContext(new HashMap<>());
-
-            session = mockMavenSession();
-            SEARCH_URI = "http://localhost:8080";
-
-            setLog(new InMemoryTestLogger());
-        }};
-
-        stubFor(get(urlPathEqualTo("/solrsearch/select")).willReturn(serverError()));
-
-        mojo.execute();
-
-        assertTrue(((InMemoryTestLogger) mojo.getLog()).errorLogs.stream().anyMatch((l) ->
-                l.contains("Failed to fetch release date for default-group:default-dependency 1.0.0")));
-        assertTrue(((InMemoryTestLogger) mojo.getLog()).errorLogs.stream().anyMatch((l) ->
-                l.contains("Failed to fetch release date for default-group:default-dependency 2.0.0")));
-        assertEquals(4, ((InMemoryTestLogger) mojo.getLog()).errorLogs.size());
-    }
-
-    @Test
-    public void apiCallToMavenTimesOut() throws Exception {
-        LibYearMojo mojo = new LibYearMojo(mockRepositorySystem(), mockAetherRepositorySystem(new HashMap<>() {{
-            put("default-dependency", new String[]{"1.0.0", "2.0.0"});
-        }})) {{
-            setProject(new MavenProjectBuilder().withDependencies(singletonList(DependencyBuilder.newBuilder()
-                    .withGroupId("default-group")
-                    .withArtifactId("default-dependency")
-                    .withVersion("1.0.0").build())).build());
-            allowProcessingAllDependencies(this);
-            setPluginContext(new HashMap<>());
-
-            session = mockMavenSession();
-            SEARCH_URI = "http://localhost:8080";
-            TIMEOUT_SECONDS = 1;
-
-            setLog(new InMemoryTestLogger());
-        }};
-
-        stubFor(get(urlPathEqualTo("/solrsearch/select")).willReturn(ok().withFixedDelay(10_000 /* ms */)));
-
-        mojo.execute();
-
-        assertTrue(((InMemoryTestLogger) mojo.getLog()).errorLogs.stream().anyMatch((l) ->
-                l.contains("Failed to get release date for default-group:default-dependency 1.0.0: request timed out")));
-        assertTrue(((InMemoryTestLogger) mojo.getLog()).errorLogs.stream().anyMatch((l) ->
-                l.contains("Failed to get release date for default-group:default-dependency 2.0.0: request timed out")));
-        assertEquals(2, ((InMemoryTestLogger) mojo.getLog()).errorLogs.size());
-    }
-
-    @Test
-    public void dependencyUpdateAvailableButFetchingReleaseDateOfNewerVersionFails() throws Exception {
-        LibYearMojo mojo = new LibYearMojo(mockRepositorySystem(), mockAetherRepositorySystem(new HashMap<>() {{
-            put("default-dependency", new String[]{"1.0.0", "1.1.0", "2.0.0"});
-        }})
-
-        ) {{
-            setProject(new MavenProjectBuilder().withDependencies(singletonList(DependencyBuilder.newBuilder()
-                    .withGroupId("default-group")
-                    .withArtifactId("default-dependency")
-                    .withVersion("1.0.0").build())).build());
-
-            allowProcessingAllDependencies(this);
-
-            setPluginContext(new HashMap<>());
-
-            session = mockMavenSession();
-            SEARCH_URI = "http://localhost:8080";
-
-            setLog(new InMemoryTestLogger());
-        }};
-
-        LocalDateTime now = LocalDateTime.now();
-
-        stubResponseFor("default-group", "default-dependency", "1.0.0", now.minusYears(1));
-        stubFor(get(urlPathEqualTo("/solrsearch/select"))
-                .withQueryParam("q", equalTo(String.format("g:%s AND a:%s AND v:%s", "default-group", "default-dependency", "2.0.0"))
-                ).withQueryParam("wt", equalTo("json")).willReturn(serverError()));
-
-        mojo.execute();
-
-        assertFalse(((InMemoryTestLogger) mojo.getLog()).infoLogs.stream().anyMatch((l) -> l.contains("default-group:default-dependency")));
-        assertTrue(((InMemoryTestLogger) mojo.getLog()).errorLogs.contains("Failed to fetch release date for default-group:default-dependency 2.0.0"));
-    }
-
-    @Test
-    public void dependencyUpdateAvailableButAPISearchDoesNotContainLatestVersion() throws Exception {
-        LibYearMojo mojo = new LibYearMojo(mockRepositorySystem(), mockAetherRepositorySystem(new HashMap<>() {{
-            put("default-dependency", new String[]{"1.0.0", "1.1.0", "2.0.0"});
-        }})
-
-        ) {{
-            setProject(new MavenProjectBuilder().withDependencies(singletonList(DependencyBuilder.newBuilder()
-                    .withGroupId("default-group")
-                    .withArtifactId("default-dependency")
-                    .withVersion("1.0.0").build())).build());
-            allowProcessingAllDependencies(this);
-            setPluginContext(new HashMap<>());
-
-            session = mockMavenSession();
-            SEARCH_URI = "http://localhost:8080";
-
-            setLog(new InMemoryTestLogger());
-        }};
-
-        LocalDateTime now = LocalDateTime.now();
-
-        stubResponseFor("default-group", "default-dependency", "1.0.0", now.minusYears(1));
-        stubFor(get(urlPathEqualTo("/solrsearch/select")).withQueryParam("q", equalTo(String.format("g:%s AND a:%s AND v:%s", "default-group", "default-dependency", "2.0.0"))).withQueryParam("wt", equalTo("json")).willReturn(ok("{\"response\":{\"docs\":[],\"numFound\":0}}")));
-
-        mojo.execute();
-
-        assertFalse(((InMemoryTestLogger) mojo.getLog()).infoLogs.stream().anyMatch((l) -> l.contains("default-group:default-dependency")));
-        assertTrue(((InMemoryTestLogger) mojo.getLog()).debugLogs.contains("Could not find artifact for default-group:default-dependency 2.0.0"));
-    }
-
-    private void allowProcessingAllDependencies(LibYearMojo mojo) throws IllegalAccessException {
-        setVariableValueToObject(mojo, "processPluginDependencies", true);
-        setVariableValueToObject(mojo, "pluginDependencyIncludes", singletonList(WildcardMatcher.WILDCARD));
-        setVariableValueToObject(mojo, "pluginDependencyExcludes", emptyList());
-        setVariableValueToObject(mojo, "processPluginDependenciesInPluginManagement", true);
-        setVariableValueToObject(mojo, "pluginManagementDependencyIncludes", singletonList(WildcardMatcher.WILDCARD));
-        setVariableValueToObject(mojo, "pluginManagementDependencyExcludes", emptyList());
-        setVariableValueToObject(mojo, "processDependencyManagement", true);
-        setVariableValueToObject(mojo, "dependencyManagementIncludes", singletonList(WildcardMatcher.WILDCARD));
-        setVariableValueToObject(mojo, "dependencyManagementExcludes", emptyList());
-        setVariableValueToObject(mojo, "dependencyIncludes", singletonList(WildcardMatcher.WILDCARD));
-        setVariableValueToObject(mojo, "dependencyExcludes", emptyList());
-    }
-
-    private static class MavenProjectBuilder {
-
-        private List<Dependency> dependencyList = Collections.emptyList();
-
-        private List<Plugin> pluginList = Collections.emptyList();
-
-        private List<Dependency> dependencyManagementDependencyList = Collections.emptyList();
-
-        private List<Plugin> pluginManagementPluginList = Collections.emptyList();
-
-        public MavenProjectBuilder withDependencies(List<Dependency> dependencyList) {
-            this.dependencyList = dependencyList;
-            return this;
-        }
-
-        public MavenProjectBuilder withPlugins(List<Plugin> pluginList) {
-            this.pluginList = pluginList;
-            return this;
-        }
-
-        public MavenProjectBuilder withDependencyManagementDependencyList(List<Dependency> dependencyList) {
-            this.dependencyManagementDependencyList = dependencyList;
-            return this;
-        }
-
-        public MavenProjectBuilder withPluginManagementPluginList(List<Plugin> pluginList) {
-            this.pluginManagementPluginList = pluginList;
-            return this;
-        }
-
-        public MavenProject build() {
-            Model model = new Model() {{
-                setGroupId("default-group");
-                setArtifactId("default-artifact");
-                setVersion("1.0.0-SNAPSHOT");
-
-                setDependencies(dependencyList);
-
-                Build build = new Build();
-                setBuild(build);
-
-                build.setPlugins(pluginList);
-
-                PluginManagement pluginManagement = new PluginManagement();
-                build.setPluginManagement(pluginManagement);
-                pluginManagement.setPlugins(pluginManagementPluginList);
-
-                DependencyManagement dependencyManagement = new DependencyManagement();
-                setDependencyManagement(dependencyManagement);
-                dependencyManagement.setDependencies(dependencyManagementDependencyList);
-            }};
-
-            MavenProject project = new MavenProject();
-            project.setModel(model);
-            project.setOriginalModel(model);
-
-            return project;
-        }
-    }
+	// TODO: Tests with version numbers being referenced by variables
+	// TODO: Test with version ranges
+	// TODO: Cleanup
+	// TODO: Run code formatter via plugin and enforce format
+	// TODO: This file is using spaces, not tabs
+
+	/**
+	 * Test factory method. Generates a Plugin object representing the specified parameters.
+	 *
+	 * @param artifactId The Maven artifact ID
+	 * @param groupId The Maven group ID
+	 * @param version The Maven version
+	 * @return The Plugin object
+	 */
+	private static Plugin pluginOf(String artifactId, String groupId, String version) {
+		Plugin plugin = new Plugin();
+		plugin.setGroupId(groupId);
+		plugin.setArtifactId(artifactId);
+		plugin.setVersion(version);
+		return plugin;
+	}
+
+	@AfterEach
+	public void reset() {
+		// TODO: Make these private and add a reset method in the mojo
+		LibYearMojo.libWeeksOutDated.set(0);
+		LibYearMojo.dependencyVersionReleaseDates.clear();
+		LibYearMojo.readyProjectsCounter.set(0);
+	}
+
+	/**
+	 * This is a basic test to ensure that a project with a single dependency correctly shows available updates.
+	 */
+	@Test
+	public void dependencyUpdateAvailable() throws Exception {
+		LibYearMojo mojo = new LibYearMojo(mockRepositorySystem(), mockAetherRepositorySystem(new HashMap<>() {{
+			put("default-dependency", new String[]{"1.0.0", "1.1.0", "2.0.0"});
+		}})
+
+		) {{
+			setProject(new MavenProjectBuilder().withDependencies(singletonList(DependencyBuilder.newBuilder().withGroupId("default-group").withArtifactId("default-dependency").withVersion("1.0.0").build())).build());
+			allowProcessingAllDependencies(this);
+			setPluginContext(new HashMap<>());
+
+			session = mockMavenSession();
+			SEARCH_URI = "http://localhost:8080";
+
+			setLog(new InMemoryTestLogger());
+		}};
+
+		LocalDateTime now = LocalDateTime.now();
+
+		// Mark version 2.0.0 as a year newer
+		// Don't stub 1.1.0, there's no need to check its version
+		stubResponseFor("default-group", "default-dependency", "1.0.0", now.minusYears(1));
+		stubResponseFor("default-group", "default-dependency", "2.0.0", now);
+
+		mojo.execute();
+
+		assertTrue(((InMemoryTestLogger) mojo.getLog()).infoLogs.stream().anyMatch((l) ->
+				l.contains("default-group:default-dependency") && l.contains("1.00 libyears")));
+		assertTrue(((InMemoryTestLogger) mojo.getLog()).errorLogs.isEmpty());
+	}
+
+	/**
+	 * This test checks that the output for dependencies with long names is formatted correctly.
+	 */
+	@Test
+	public void dependencyUpdateWithLongNameAvailable() throws Exception {
+		LibYearMojo mojo = new LibYearMojo(mockRepositorySystem(), mockAetherRepositorySystem(new HashMap<>() {{
+			put("default-dependency-with-very-very-long-name", new String[]{"1.0.0", "1.1.0", "2.0.0"});
+		}})
+
+		) {{
+			setProject(new MavenProjectBuilder().withDependencies(singletonList(DependencyBuilder
+					.newBuilder().withGroupId("default-group")
+					.withArtifactId("default-dependency-with-very-very-long-name").withVersion("1.0.0").build())).build());
+			allowProcessingAllDependencies(this);
+			setPluginContext(new HashMap<>());
+
+			session = mockMavenSession();
+			SEARCH_URI = "http://localhost:8080";
+
+			setLog(new InMemoryTestLogger());
+		}};
+
+		LocalDateTime now = LocalDateTime.now();
+
+		// Mark version 2.0.0 as a year newer
+		stubResponseFor("default-group", "default-dependency-with-very-very-long-name", "1.0.0", now.minusYears(1));
+		stubResponseFor("default-group", "default-dependency-with-very-very-long-name", "2.0.0", now);
+
+		mojo.execute();
+
+		// TODO: Implement wrapping for libyear output for dependencies with long names then update this test
+		assertTrue(((InMemoryTestLogger) mojo.getLog()).infoLogs.stream().anyMatch((l) ->
+				l.contains("default-group:default-dependency-with-very-very-long-name") && l.contains("1.00 libyears")));
+		assertTrue(((InMemoryTestLogger) mojo.getLog()).errorLogs.isEmpty());
+	}
+
+	/**
+	 * The plugin should cache the result of API calls to find the release date of every dependency that it makes.
+	 * This test ensures that despite running the plugin twice, we only make one API call for each dependency version.
+	 */
+	@Test
+	public void cacheIsUsedForDependencyVersions() throws Exception {
+		// Run one of the tests twice, which should only trigger one fetch per dependency version
+		dependencyUpdateAvailable();
+		dependencyUpdateAvailable();
+
+		// One call for v1.0.0
+		verify(1,
+				getRequestedFor(urlPathEqualTo("/solrsearch/select"))
+						.withQueryParam("q", equalTo("g:default-group AND a:default-dependency AND v:1.0.0")));
+
+		// One call for v2.0.0
+		verify(1, getRequestedFor(urlPathEqualTo("/solrsearch/select"))
+				.withQueryParam("q", equalTo("g:default-group AND a:default-dependency AND v:2.0.0")));
+	}
+
+	@Test
+	public void dependencyUpdateAvailableWhenVersionSpecifiedInDependencyManagement() throws Exception {
+		LibYearMojo mojo = new LibYearMojo(mockRepositorySystem(), mockAetherRepositorySystem(new HashMap<>() {{
+			put("default-dependency", new String[]{"1.0.0", "1.1.0", "2.0.0"});
+		}})
+
+		) {{
+			setProject(new MavenProjectBuilder()
+					.withDependencies(singletonList(DependencyBuilder.newBuilder()
+							.withGroupId("default-group")
+							.withArtifactId("default-dependency")
+							.withVersion("1.0.0") // This is overridden by dependencyManagement
+					.build()))
+					.withDependencyManagementDependencyList(
+							singletonList(DependencyBuilder.newBuilder()
+									.withGroupId("default-group")
+									.withArtifactId("default-dependency")
+									.withVersion("1.1.0").build()))
+					.build());
+			allowProcessingAllDependencies(this);
+			setPluginContext(new HashMap<>());
+
+			session = mockMavenSession();
+			SEARCH_URI = "http://localhost:8080";
+
+			setLog(new InMemoryTestLogger());
+		}};
+
+		LocalDateTime now = LocalDateTime.now();
+
+		// Mark version 2.0.0 as a year newer than the version specified by dependencyManagement
+		stubResponseFor("default-group", "default-dependency", "1.0.0", now.minusYears(2));
+		stubResponseFor("default-group", "default-dependency", "1.1.0", now.minusYears(1));
+		stubResponseFor("default-group", "default-dependency", "2.0.0", now);
+
+		mojo.execute();
+
+		assertTrue(((InMemoryTestLogger) mojo.getLog()).infoLogs.stream().anyMatch((l) -> l.contains("default-group:default-dependency") && l.contains("1.00 libyears")));
+
+		assertTrue(((InMemoryTestLogger) mojo.getLog()).errorLogs.isEmpty());
+	}
+
+	/**
+	 * This test has a project with a two-year-old dependency where the dependency version is overridden by the
+	 * dependencyManagement section to use a one-year-old version, but the plugin setting enableDependencyManagement is
+	 * set to false. We should ignore the one-year-old version and suggest that the dependency is two years out-of-date.
+	 */
+	@Test
+	public void dependencyUpdateAvailableWhenVersionSpecifiedInDependencyManagementWhereProcessDependencyManagementIsDisabled() throws Exception {
+		LibYearMojo mojo = new LibYearMojo(mockRepositorySystem(), mockAetherRepositorySystem(new HashMap<>() {{
+			put("default-dependency", new String[]{"1.0.0", "1.1.0", "2.0.0"});
+		}})
+
+		) {{
+			setProject(new MavenProjectBuilder()
+					.withDependencies(singletonList(DependencyBuilder.newBuilder()
+							.withGroupId("default-group")
+							.withArtifactId("default-dependency")
+							.withVersion("1.0.0") // This is overridden by dependencyManagement
+							.build()))
+					.withDependencyManagementDependencyList(
+							singletonList(DependencyBuilder.newBuilder()
+									.withGroupId("default-group")
+									.withArtifactId("default-dependency")
+									.withVersion("1.1.0").build()))
+					.build());
+			allowProcessingAllDependencies(this);
+			setVariableValueToObject(this, "processDependencyManagement", false);
+			setPluginContext(new HashMap<>());
+
+			session = mockMavenSession();
+			SEARCH_URI = "http://localhost:8080";
+
+			setLog(new InMemoryTestLogger());
+		}};
+
+		LocalDateTime now = LocalDateTime.now();
+
+		// Mark version 2.0.0 as a year newer than the version specified by dependencyManagement
+		stubResponseFor("default-group", "default-dependency", "1.0.0", now.minusYears(2));
+		stubResponseFor("default-group", "default-dependency", "1.1.0", now.minusYears(1));
+		stubResponseFor("default-group", "default-dependency", "2.0.0", now);
+
+		mojo.execute();
+
+		assertTrue(((InMemoryTestLogger) mojo.getLog()).infoLogs.stream().anyMatch((l) -> l.contains("default-group:default-dependency") && l.contains("2.00 libyears")));
+
+		assertTrue(((InMemoryTestLogger) mojo.getLog()).errorLogs.isEmpty());
+	}
+
+	/**
+	 * This test has a dependency with version 1.0.0, which is overridden by
+	 * dependencyManagement to 1.1.0. Version 2.0.0 is available.
+	 * <p>
+	 * We ensure that the proposed change is the libyears between 1.1.0 and
+	 * 2.0.0.
+	 */
+	@Test
+	public void dependencyUpdateAvailableDependencyDefinedInDependencyManagement() throws Exception {
+		LibYearMojo mojo = new LibYearMojo(mockRepositorySystem(), mockAetherRepositorySystem(new HashMap<>() {{
+			put("default-dependency", new String[]{"1.0.0", "1.1.0", "2.0.0"});
+		}})
+
+		) {{
+			setProject(new MavenProjectBuilder().withDependencies(
+					singletonList(DependencyBuilder.newBuilder()
+							.withGroupId("default-group")
+							.withArtifactId("default-dependency")
+							.withVersion("1.0.0")
+							.build()))
+					.withDependencyManagementDependencyList(singletonList(DependencyBuilder.newBuilder()
+							.withGroupId("default-group")
+							.withArtifactId("default-dependency")
+							.withVersion("1.1.0")
+							.build()))
+					.build());
+			allowProcessingAllDependencies(this);
+			setPluginContext(new HashMap<>());
+
+			session = mockMavenSession();
+			SEARCH_URI = "http://localhost:8080";
+
+			setLog(new InMemoryTestLogger());
+		}};
+
+		LocalDateTime now = LocalDateTime.now();
+
+		// Mark version 2.0.0 as a year newer. The current dependency version is 1.1.0, overridden from 1.0.0 by
+		// dependencyManagement
+
+		// TODO: This first stub probably shouldn't be needed as we shouldn't need to fetch the release year of this version
+		// but without it, the test fails.
+		stubResponseFor("default-group", "default-dependency", "1.0.0", now.minusYears(10));
+		stubResponseFor("default-group", "default-dependency", "1.1.0", now.minusYears(1));
+		stubResponseFor("default-group", "default-dependency", "2.0.0", now);
+
+		mojo.execute();
+
+		assertTrue(((InMemoryTestLogger) mojo.getLog()).infoLogs.stream().anyMatch(
+				(l) -> l.contains("default-group:default-dependency") && l.contains("1.00 libyears")));
+		assertTrue(((InMemoryTestLogger) mojo.getLog()).errorLogs.isEmpty());
+	}
+
+	@Test
+	public void pluginVersionUpdateAvailable() throws Exception {
+		Plugin plugin = pluginOf("default-plugin", "default-group", "1.0.0");
+		plugin.setDependencies(singletonList(dependencyFor("default-group", "default-dependency", "1.0.0")));
+
+		LibYearMojo mojo = new LibYearMojo(mockRepositorySystem(), mockAetherRepositorySystem(new HashMap<>() {{
+			put("default-dependency", new String[]{"1.0.0", "1.1.0", "2.0.0"});
+		}})
+
+		) {{
+			setProject(new MavenProjectBuilder().withPlugins(singletonList(plugin)).build());
+
+			allowProcessingAllDependencies(this);
+			setPluginContext(new HashMap<>());
+
+			session = mockMavenSession();
+			SEARCH_URI = "http://localhost:8080";
+
+			setLog(new InMemoryTestLogger());
+		}};
+
+		LocalDateTime now = LocalDateTime.now();
+
+		// Mark version 2.0.0 as a year newer
+		stubResponseFor("default-group", "default-dependency", "1.0.0", now.minusYears(1));
+		stubResponseFor("default-group", "default-dependency", "2.0.0", now);
+
+		mojo.execute();
+
+		assertTrue(((InMemoryTestLogger) mojo.getLog()).infoLogs.stream().anyMatch((l) ->
+				l.contains("default-group:default-dependency") && l.contains("1.00 libyears")));
+		assertTrue(((InMemoryTestLogger) mojo.getLog()).errorLogs.isEmpty());
+	}
+
+	/**
+	 * This test has a plugin version 1.0.0 which has a dependency on another
+	 * artifact version 1.0.1. That version is overridden in dependency management
+	 * to 1.1.0. Version 2.0.0 is available.
+	 * <p>
+	 * This test ensures we suggest the libyears between 1.1.0 and 2.0.0.
+	 */
+	@Test
+	public void pluginVersionUpdateAvailableDependencyDefinedInDependencyManagement() throws Exception {
+		Plugin plugin = pluginOf("default-plugin", "default-group", "1.0.0");
+		plugin.setDependencies(singletonList(dependencyFor("default-group", "default-dependency", "1.0.1")));
+
+		LibYearMojo mojo = new LibYearMojo(mockRepositorySystem(), mockAetherRepositorySystem(new HashMap<>() {{
+			put("default-dependency", new String[]{"1.0.0", "1.1.0", "2.0.0"});
+		}})
+
+		) {{
+			setProject(new MavenProjectBuilder().withPlugins(singletonList(plugin)).withDependencyManagementDependencyList(singletonList(DependencyBuilder.newBuilder().withGroupId("default-group").withArtifactId("default-dependency").withVersion("1.1.0").build())).build());
+
+			allowProcessingAllDependencies(this);
+			setPluginContext(new HashMap<>());
+
+			session = mockMavenSession();
+			SEARCH_URI = "http://localhost:8080";
+
+			setLog(new InMemoryTestLogger());
+		}};
+
+		LocalDateTime now = LocalDateTime.now();
+
+		// Mark version 2.0.0 as a year newer
+		stubResponseFor("default-group", "default-dependency", "1.0.1", now.minusYears(2));
+		stubResponseFor("default-group", "default-dependency", "1.1.0", now.minusYears(1));
+		stubResponseFor("default-group", "default-dependency", "2.0.0", now);
+
+		mojo.execute();
+
+		assertTrue(((InMemoryTestLogger) mojo.getLog()).infoLogs.stream().anyMatch((l) ->
+				l.contains("default-group:default-dependency") && l.contains("1.00 libyears")));
+		assertTrue(((InMemoryTestLogger) mojo.getLog()).errorLogs.isEmpty());
+	}
+
+	/**
+	 * This test has a plugin version 1.0.0. That version is overridden in plugin management to 1.1.0.
+	 * Version 2.0.0 is available.
+	 * <p>
+	 * This test ensures we suggest the libyears between 1.1.0 and 2.0.0.
+	 */
+	@Test
+	public void pluginVersionUpdateAvailableDependencyDefinedInPluginManagement() throws Exception {
+		Plugin plugin = pluginOf("default-plugin", "default-group", "1.0.0");
+		plugin.setDependencies(singletonList(dependencyFor("default-group", "default-dependency", "1.0.1")));
+
+		Plugin managedPlugin = pluginOf("default-plugin", "default-group", "1.0.0");
+		plugin.setDependencies(singletonList(dependencyFor("default-group", "default-dependency", "1.1.0")));
+
+		LibYearMojo mojo = new LibYearMojo(mockRepositorySystem(), mockAetherRepositorySystem(new HashMap<>() {{
+			put("default-dependency", new String[]{"1.0.0", "1.1.0", "2.0.0"});
+		}})
+
+		) {{
+			setProject(new MavenProjectBuilder()
+					.withPlugins(singletonList(plugin))
+					.withPluginManagementPluginList(singletonList(managedPlugin)).build());
+
+			allowProcessingAllDependencies(this);
+
+			setPluginContext(new HashMap<>());
+
+			session = mockMavenSession();
+			SEARCH_URI = "http://localhost:8080";
+
+			setLog(new InMemoryTestLogger());
+		}};
+
+		LocalDateTime now = LocalDateTime.now();
+
+		// Mark version 2.0.0 as a year newer
+		stubResponseFor("default-group", "default-dependency", "1.1.0", now.minusYears(1));
+		stubResponseFor("default-group", "default-dependency", "2.0.0", now);
+
+		mojo.execute();
+
+		assertTrue(((InMemoryTestLogger) mojo.getLog()).infoLogs.stream().anyMatch((l) -> l.contains("default-group:default-dependency") && l.contains("1.00 libyears")));
+		assertTrue(((InMemoryTestLogger) mojo.getLog()).errorLogs.isEmpty());
+	}
+
+	private Dependency dependencyFor(String groupID, String artifactId, String version) {
+		Dependency dep = new Dependency();
+		dep.setGroupId(groupID);
+		dep.setArtifactId(artifactId);
+		dep.setVersion(version);
+		return dep;
+	}
+
+	/**
+	 * Stub the Maven search API response that looks for release information for a particular version of a particular
+	 * artifact
+	 */
+	private void stubResponseFor(String groupId, String artifactId, String version, LocalDateTime time) {
+		stubFor(get(urlPathEqualTo("/solrsearch/select")).withQueryParam("q", equalTo(String.format("g:%s AND a:%s AND v:%s", groupId, artifactId, version))).withQueryParam("wt", equalTo("json")).willReturn(ok(getJSONResponseForVersion(groupId, artifactId, version, time))));
+	}
+
+	/**
+	 * Simulate the JSON response from the Maven Central repository search API. Docs available at
+	 * <a href="https://central.sonatype.org/search/rest-api-guide/">here</a>.
+	 */
+	private String getJSONResponseForVersion(String groupId, String artifactId, String version, LocalDateTime releaseDate) {
+		JSONObject root = new JSONObject();
+		JSONObject response = new JSONObject();
+		JSONArray versions = new JSONArray();
+		JSONObject newVersion = new JSONObject();
+
+		newVersion.put("id", String.format("%s:%s:%s", groupId, artifactId, version));
+		newVersion.put("g", groupId);
+		newVersion.put("a", artifactId);
+		newVersion.put("v", version);
+		newVersion.put("p", "jar");
+		newVersion.put("timestamp", releaseDate.toEpochSecond(ZoneOffset.UTC) * 1000); // API response is in millis
+
+		versions.put(newVersion);
+		response.put("docs", versions);
+		response.put("numFound", 1);
+		root.put("response", response);
+
+		return root.toString();
+	}
+
+	@Test
+	public void apiCallToMavenFails() throws Exception {
+		LibYearMojo mojo = new LibYearMojo(mockRepositorySystem(), mockAetherRepositorySystem(new HashMap<>() {{
+			put("default-dependency", new String[]{"1.0.0", "2.0.0"});
+		}})) {{
+			setProject(new MavenProjectBuilder().withDependencies(singletonList(DependencyBuilder.newBuilder()
+					.withGroupId("default-group")
+					.withArtifactId("default-dependency")
+					.withVersion("1.0.0").build()))
+				.build());
+			allowProcessingAllDependencies(this);
+			setPluginContext(new HashMap<>());
+
+			session = mockMavenSession();
+			SEARCH_URI = "http://localhost:8080";
+
+			setLog(new InMemoryTestLogger());
+		}};
+
+		stubFor(get(urlPathEqualTo("/solrsearch/select")).willReturn(serverError()));
+
+		mojo.execute();
+
+		assertTrue(((InMemoryTestLogger) mojo.getLog()).errorLogs.stream().anyMatch((l) ->
+				l.contains("Failed to fetch release date for default-group:default-dependency 1.0.0")));
+		assertTrue(((InMemoryTestLogger) mojo.getLog()).errorLogs.stream().anyMatch((l) ->
+				l.contains("Failed to fetch release date for default-group:default-dependency 2.0.0")));
+		assertEquals(4, ((InMemoryTestLogger) mojo.getLog()).errorLogs.size());
+	}
+
+	@Test
+	public void apiCallToMavenTimesOut() throws Exception {
+		LibYearMojo mojo = new LibYearMojo(mockRepositorySystem(), mockAetherRepositorySystem(new HashMap<>() {{
+			put("default-dependency", new String[]{"1.0.0", "2.0.0"});
+		}})) {{
+			setProject(new MavenProjectBuilder().withDependencies(singletonList(DependencyBuilder.newBuilder()
+					.withGroupId("default-group")
+					.withArtifactId("default-dependency")
+					.withVersion("1.0.0").build())).build());
+			allowProcessingAllDependencies(this);
+			setPluginContext(new HashMap<>());
+
+			session = mockMavenSession();
+			SEARCH_URI = "http://localhost:8080";
+			TIMEOUT_SECONDS = 1;
+
+			setLog(new InMemoryTestLogger());
+		}};
+
+		stubFor(get(urlPathEqualTo("/solrsearch/select")).willReturn(ok().withFixedDelay(10_000 /* ms */)));
+
+		mojo.execute();
+
+		assertTrue(((InMemoryTestLogger) mojo.getLog()).errorLogs.stream().anyMatch((l) ->
+				l.contains("Failed to get release date for default-group:default-dependency 1.0.0: request timed out")));
+		assertTrue(((InMemoryTestLogger) mojo.getLog()).errorLogs.stream().anyMatch((l) ->
+				l.contains("Failed to get release date for default-group:default-dependency 2.0.0: request timed out")));
+		assertEquals(2, ((InMemoryTestLogger) mojo.getLog()).errorLogs.size());
+	}
+
+	@Test
+	public void dependencyUpdateAvailableButFetchingReleaseDateOfNewerVersionFails() throws Exception {
+		LibYearMojo mojo = new LibYearMojo(mockRepositorySystem(), mockAetherRepositorySystem(new HashMap<>() {{
+			put("default-dependency", new String[]{"1.0.0", "1.1.0", "2.0.0"});
+		}})
+
+		) {{
+			setProject(new MavenProjectBuilder().withDependencies(singletonList(DependencyBuilder.newBuilder()
+					.withGroupId("default-group")
+					.withArtifactId("default-dependency")
+					.withVersion("1.0.0").build())).build());
+
+			allowProcessingAllDependencies(this);
+
+			setPluginContext(new HashMap<>());
+
+			session = mockMavenSession();
+			SEARCH_URI = "http://localhost:8080";
+
+			setLog(new InMemoryTestLogger());
+		}};
+
+		LocalDateTime now = LocalDateTime.now();
+
+		stubResponseFor("default-group", "default-dependency", "1.0.0", now.minusYears(1));
+		stubFor(get(urlPathEqualTo("/solrsearch/select"))
+				.withQueryParam("q", equalTo(String.format("g:%s AND a:%s AND v:%s", "default-group", "default-dependency", "2.0.0"))
+				).withQueryParam("wt", equalTo("json")).willReturn(serverError()));
+
+		mojo.execute();
+
+		assertFalse(((InMemoryTestLogger) mojo.getLog()).infoLogs.stream().anyMatch((l) -> l.contains("default-group:default-dependency")));
+		assertTrue(((InMemoryTestLogger) mojo.getLog()).errorLogs.contains("Failed to fetch release date for default-group:default-dependency 2.0.0"));
+	}
+
+	@Test
+	public void dependencyUpdateAvailableButAPISearchDoesNotContainLatestVersion() throws Exception {
+		LibYearMojo mojo = new LibYearMojo(mockRepositorySystem(), mockAetherRepositorySystem(new HashMap<>() {{
+			put("default-dependency", new String[]{"1.0.0", "1.1.0", "2.0.0"});
+		}})
+
+		) {{
+			setProject(new MavenProjectBuilder().withDependencies(singletonList(DependencyBuilder.newBuilder()
+					.withGroupId("default-group")
+					.withArtifactId("default-dependency")
+					.withVersion("1.0.0").build())).build());
+			allowProcessingAllDependencies(this);
+			setPluginContext(new HashMap<>());
+
+			session = mockMavenSession();
+			SEARCH_URI = "http://localhost:8080";
+
+			setLog(new InMemoryTestLogger());
+		}};
+
+		LocalDateTime now = LocalDateTime.now();
+
+		stubResponseFor("default-group", "default-dependency", "1.0.0", now.minusYears(1));
+		stubFor(get(urlPathEqualTo("/solrsearch/select")).withQueryParam("q", equalTo(String.format("g:%s AND a:%s AND v:%s", "default-group", "default-dependency", "2.0.0"))).withQueryParam("wt", equalTo("json")).willReturn(ok("{\"response\":{\"docs\":[],\"numFound\":0}}")));
+
+		mojo.execute();
+
+		assertFalse(((InMemoryTestLogger) mojo.getLog()).infoLogs.stream().anyMatch((l) -> l.contains("default-group:default-dependency")));
+		assertTrue(((InMemoryTestLogger) mojo.getLog()).debugLogs.contains("Could not find artifact for default-group:default-dependency 2.0.0"));
+	}
+
+	private void allowProcessingAllDependencies(LibYearMojo mojo) throws IllegalAccessException {
+		setVariableValueToObject(mojo, "processPluginDependencies", true);
+		setVariableValueToObject(mojo, "pluginDependencyIncludes", singletonList(WildcardMatcher.WILDCARD));
+		setVariableValueToObject(mojo, "pluginDependencyExcludes", emptyList());
+		setVariableValueToObject(mojo, "processPluginDependenciesInPluginManagement", true);
+		setVariableValueToObject(mojo, "pluginManagementDependencyIncludes", singletonList(WildcardMatcher.WILDCARD));
+		setVariableValueToObject(mojo, "pluginManagementDependencyExcludes", emptyList());
+		setVariableValueToObject(mojo, "processDependencyManagement", true);
+		setVariableValueToObject(mojo, "dependencyManagementIncludes", singletonList(WildcardMatcher.WILDCARD));
+		setVariableValueToObject(mojo, "dependencyManagementExcludes", emptyList());
+		setVariableValueToObject(mojo, "dependencyIncludes", singletonList(WildcardMatcher.WILDCARD));
+		setVariableValueToObject(mojo, "dependencyExcludes", emptyList());
+	}
+
+	private void configurePluginSettings(LibYearMojo mojo, String settingName, Object value) throws IllegalAccessException {
+		setVariableValueToObject(mojo, settingName, value);
+	}
 }

--- a/src/test/java/com/mfoot/mojo/libyear/MavenProjectBuilder.java
+++ b/src/test/java/com/mfoot/mojo/libyear/MavenProjectBuilder.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2023 Martin Foot
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mfoot.mojo.libyear;
+
+import org.apache.maven.model.Build;
+import org.apache.maven.model.Dependency;
+import org.apache.maven.model.DependencyManagement;
+import org.apache.maven.model.Model;
+import org.apache.maven.model.Plugin;
+import org.apache.maven.model.PluginManagement;
+import org.apache.maven.project.MavenProject;
+
+import java.util.Collections;
+import java.util.List;
+
+class MavenProjectBuilder {
+
+	private List<Dependency> dependencyList = Collections.emptyList();
+
+	private List<Plugin> pluginList = Collections.emptyList();
+
+	private List<Dependency> dependencyManagementDependencyList = Collections.emptyList();
+
+	private List<Plugin> pluginManagementPluginList = Collections.emptyList();
+
+	public MavenProjectBuilder withDependencies(List<Dependency> dependencyList) {
+		this.dependencyList = dependencyList;
+		return this;
+	}
+
+	public MavenProjectBuilder withPlugins(List<Plugin> pluginList) {
+		this.pluginList = pluginList;
+		return this;
+	}
+
+	public MavenProjectBuilder withDependencyManagementDependencyList(List<Dependency> dependencyList) {
+		this.dependencyManagementDependencyList = dependencyList;
+		return this;
+	}
+
+	public MavenProjectBuilder withPluginManagementPluginList(List<Plugin> pluginList) {
+		this.pluginManagementPluginList = pluginList;
+		return this;
+	}
+
+	public MavenProject build() {
+		Model model = new Model() {{
+			setGroupId("default-group");
+			setArtifactId("default-artifact");
+			setVersion("1.0.0-SNAPSHOT");
+
+			setDependencies(dependencyList);
+
+			Build build = new Build();
+			setBuild(build);
+
+			build.setPlugins(pluginList);
+
+			PluginManagement pluginManagement = new PluginManagement();
+			build.setPluginManagement(pluginManagement);
+			pluginManagement.setPlugins(pluginManagementPluginList);
+
+			DependencyManagement dependencyManagement = new DependencyManagement();
+			setDependencyManagement(dependencyManagement);
+			dependencyManagement.setDependencies(dependencyManagementDependencyList);
+		}};
+
+		MavenProject project = new MavenProject();
+		project.setModel(model);
+		project.setOriginalModel(model);
+
+		return project;
+	}
+}


### PR DESCRIPTION
It looks like the default IntelliJ style is to use spaces, not tabs. I'm used to tabs, so until I add the CheckStyle plugin (or similar), this MR changes indentation to tabs.

It also moves the `MavenProjectBuilder` test class into its own class to keep the `LibYearMojo` class file cleaner.