### PR TITLE
Add logger implementation for tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -146,6 +146,16 @@
 			<artifactId>guava</artifactId>
 			<version>31.1-jre</version>
 		</dependency>
+		<dependency>
+			<!--
+				Logging for this plugin uses SLF4J, but we don't want to force a logger implementation on projects using
+				the plugin, so ensure this is test-scoped.
+			-->
+			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-simple</artifactId>
+			<version>1.7.36</version>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 
 	<build>


### PR DESCRIPTION
The maven project ecosystem uses SLF4J, and this project inherits an `slf4j-api` dependency. It doesn't inherit a logger implementation though (and it shouldn't), so currently running JUnit tests produces the following output:

```
SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".
SLF4J: Defaulting to no-operation (NOP) logger implementation
SLF4J: See http://www.slf4j.org/codes.html#StaticLoggerBinder for further details.
```

This MR fixes this by adding a logger implementation, in this case `slf4j-simple` in the `test` scope.