### PR TITLE
Switch to Apache Maven HTTP Client and implement retry behaviour

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -165,6 +165,16 @@
 			<version>31.1-jre</version>
 		</dependency>
 		<dependency>
+			<groupId>org.apache.httpcomponents</groupId>
+			<artifactId>httpclient</artifactId>
+			<version>4.5.13</version>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.httpcomponents</groupId>
+			<artifactId>httpcore</artifactId>
+			<version>4.4.15</version>
+		</dependency>
+		<dependency>
 			<groupId>org.codehaus.plexus</groupId>
 			<artifactId>plexus-utils</artifactId>
 			<version>3.5.0</version>


### PR DESCRIPTION
The Maven Search API fails fairly regularly, presumably due to poor loadbalancing health. This MR changes from the Java HTTP client to the Apache HTTP client which retries by default. It also adds better testing for server error responses and timeouts.

Technically this might allow the project to build on JDK8, but since it's EOL ideally it's not something the project should support (though a lot of projects are still stuck on old JDKs).

One concern is that the plugin could be abusing the API. There's no usage guidelines and its use will be far below other clients, but perhaps some rate limiting should be added to requests.