### PR TITLE
Rename mojo from libyear-report to analyze - resolves #17

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,34 +11,29 @@ This plugin helps you see how outdated your Maven project dependencies are via t
 [INFO] Building libyear-maven-plugin Maven Mojo 0.0.1-SNAPSHOT
 [INFO] ----------------------------[ maven-plugin ]----------------------------
 [INFO]
-[INFO] --- libyear-maven-plugin:0.0.1-SNAPSHOT:libyear-report (default-cli) @ libyear-maven-plugin ---
+[INFO] --- libyear-maven-plugin:0.0.1-SNAPSHOT:analyze (default-cli) @ libyear-maven-plugin ---
 [INFO]
 [INFO] The following dependencies in Dependencies have newer versions:
-[INFO]   org.apache.maven.plugin-tools:maven-plugin-annotations . 0.79 libyears
-[INFO]   org.apache.maven.resolver:maven-resolver-api ........... 1.56 libyears
-[INFO]   org.apache.maven:maven-compat .......................... 0.52 libyears
-[INFO]   org.apache.maven.wagon:wagon-provider-api .............. 0.98 libyears
-[INFO]   org.apache.maven:maven-model ........................... 0.52 libyears
-[INFO]   org.apache.maven:maven-plugin-api ...................... 0.52 libyears
-[INFO]   org.mockito:mockito-junit-jupiter ...................... 0.04 libyears
-[INFO]   org.apache.maven:maven-artifact ........................ 0.52 libyears
-[INFO]   org.apache.maven:maven-core ............................ 0.52 libyears
+[INFO]   org.apache.httpcomponents:httpclient ................... 2.15 libyears
+[INFO]   org.apache.httpcomponents:httpcore ..................... 0.98 libyears
+[INFO]   org.apache.maven:maven-settings ........................ 0.52 libyears
+[INFO]   org.junit.jupiter:junit-jupiter-engine ................. 0.31 libyears
 [INFO]
-[INFO] Total years outdated: 5.96
+[INFO] Total years outdated: 3.96
 ```
 
 The plugin requires JDK 11+. It is heavily based on the [MojoHaus Versions Maven Plugin](https://www.mojohaus.org/versions/versions-maven-plugin/index.html).
 
 ## Usage
 
-The plugin provides a single goal, `libyear-report`. This can be executed
+The plugin provides a single goal, `analyze`. This can be executed
 directly via the command-line with Maven, or it can be incorporated as part of
 a build inside `pom.xml`.
 
 ### Command-line
 
 ```shell
-mvn com.mfoot:libyear-maven-plugin:0.0.1-SNAPSHOT:libyear-report
+mvn com.mfoot:libyear-maven-plugin:0.0.1-SNAPSHOT:analyze
 ```
 
 ### Plugin execution
@@ -52,9 +47,9 @@ mvn com.mfoot:libyear-maven-plugin:0.0.1-SNAPSHOT:libyear-report
       <version>0.0.1-SNAPSHOT</version>
       <executions>
         <execution>
-          <id>libyear-report</id>
+          <id>libyear-analysis</id>
           <goals>
-            <goal>libyear-report</goal>
+            <goal>analyze</goal>
           </goals>
         </execution>
       </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -262,7 +262,7 @@
 					<execution>
 						<id>libyear-report</id>
 						<goals>
-							<goal>libyear-report</goal>
+							<goal>analyze</goal>
 						</goals>
 						<phase>install</phase>
 					</execution>

--- a/src/it/basic-single-dependency-with-version-in-property/invoker.properties
+++ b/src/it/basic-single-dependency-with-version-in-property/invoker.properties
@@ -1,1 +1,1 @@
-invoker.goals.1=${project.groupId}:${project.artifactId}:${project.version}:libyear-report
+invoker.goals.1=${project.groupId}:${project.artifactId}:${project.version}:analyze

--- a/src/it/basic-single-dependency/invoker.properties
+++ b/src/it/basic-single-dependency/invoker.properties
@@ -1,1 +1,1 @@
-invoker.goals.1=${project.groupId}:${project.artifactId}:${project.version}:libyear-report
+invoker.goals.1=${project.groupId}:${project.artifactId}:${project.version}:analyze

--- a/src/it/dependency-defined-twice/invoker.properties
+++ b/src/it/dependency-defined-twice/invoker.properties
@@ -1,1 +1,1 @@
-invoker.goals.1=${project.groupId}:${project.artifactId}:${project.version}:libyear-report
+invoker.goals.1=${project.groupId}:${project.artifactId}:${project.version}:analyze

--- a/src/it/dependency-defined-twice/pom.xml
+++ b/src/it/dependency-defined-twice/pom.xml
@@ -7,7 +7,7 @@
 	<artifactId>basic-single-dependency</artifactId>
 	<version>1.0</version>
 	<packaging>pom</packaging>
-	<name>libyear-report</name>
+	<name>libyear-analyze</name>
 	<url>http://localhost/</url>
 
 	<description>

--- a/src/it/no-dependencies/invoker.properties
+++ b/src/it/no-dependencies/invoker.properties
@@ -1,1 +1,1 @@
-invoker.goals.1=${project.groupId}:${project.artifactId}:${project.version}:libyear-report
+invoker.goals.1=${project.groupId}:${project.artifactId}:${project.version}:analyze

--- a/src/main/java/com/mfoot/mojo/libyear/LibYearMojo.java
+++ b/src/main/java/com/mfoot/mojo/libyear/LibYearMojo.java
@@ -79,7 +79,7 @@ import static org.codehaus.mojo.versions.utils.MavenProjectUtils.extractDependen
  * Analyze dependencies and calculate how old they are.
  */
 // TODO: Test whether or not we can set `threadSafe = true`
-@Mojo(name = "libyear-report", defaultPhase = LifecyclePhase.VERIFY)
+@Mojo(name = "analyze", defaultPhase = LifecyclePhase.VERIFY)
 public class LibYearMojo extends AbstractMojo {
 	/**
 	 * Screen width for formatting the output number of libyears


### PR DESCRIPTION
Since the plugin is called `libyear-maven-plugin`, Maven will automatically add the prefix `libyear:analyze`, but when called directly from the command line we just need `analyze`.

This change makes it sound less like a report, which is a keyword in Maven, used for generating HTML output for documentation.