### PR TITLE
Add the spotless plugin for the Palantir Code Formatter

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -273,6 +273,24 @@
 				<artifactId>maven-site-plugin</artifactId>
 				<version>3.12.1</version>
 			</plugin>
+			<plugin>
+				<groupId>com.diffplug.spotless</groupId>
+				<artifactId>spotless-maven-plugin</artifactId>
+				<version>2.30.0</version>
+				<configuration>
+					<java>
+						<palantirJavaFormat />
+					</java>
+				</configuration>
+				<executions>
+					<execution>
+						<goals>
+							<goal>check</goal>
+						</goals>
+						<phase>compile</phase>
+					</execution>
+				</executions>
+			</plugin>
 		</plugins>
 	</build>
 

--- a/src/main/java/com/mfoot/mojo/libyear/LibYearMojo.java
+++ b/src/main/java/com/mfoot/mojo/libyear/LibYearMojo.java
@@ -16,7 +16,32 @@
 
 package com.mfoot.mojo.libyear;
 
+import static java.util.Collections.emptySet;
+import static org.codehaus.mojo.versions.filtering.DependencyFilter.filterDependencies;
+import static org.codehaus.mojo.versions.utils.MavenProjectUtils.extractDependenciesFromDependencyManagement;
+import static org.codehaus.mojo.versions.utils.MavenProjectUtils.extractDependenciesFromPlugins;
+import static org.codehaus.mojo.versions.utils.MavenProjectUtils.extractPluginDependenciesFromPluginsInPluginManagement;
+
 import com.google.common.collect.Maps;
+import java.io.IOException;
+import java.net.SocketTimeoutException;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.Collectors;
+import javax.inject.Inject;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.http.HttpResponseInterceptor;
 import org.apache.http.client.config.RequestConfig;
@@ -46,719 +71,710 @@ import org.codehaus.mojo.versions.api.DefaultVersionsHelper;
 import org.codehaus.mojo.versions.api.VersionsHelper;
 import org.codehaus.mojo.versions.filtering.WildcardMatcher;
 import org.codehaus.mojo.versions.utils.DependencyComparator;
-import org.codehaus.mojo.versions.utils.MavenProjectUtils;
 import org.codehaus.plexus.util.StringUtils;
 import org.json.JSONObject;
 
-import javax.inject.Inject;
-import java.io.IOException;
-import java.net.SocketTimeoutException;
-import java.net.URI;
-import java.nio.charset.StandardCharsets;
-import java.time.Instant;
-import java.time.LocalDate;
-import java.time.ZoneId;
-import java.time.temporal.ChronoUnit;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.Set;
-import java.util.TreeSet;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.atomic.AtomicLong;
-
-import static java.util.Collections.emptySet;
-import static org.codehaus.mojo.versions.filtering.DependencyFilter.filterDependencies;
-import static org.codehaus.mojo.versions.utils.MavenProjectUtils.extractDependenciesFromDependencyManagement;
-
-/**
- * Analyze dependencies and calculate how old they are.
- */
+/** Analyze dependencies and calculate how old they are. */
 // TODO: Test whether or not we can set `threadSafe = true`
 @Mojo(name = "analyze", defaultPhase = LifecyclePhase.VERIFY)
 public class LibYearMojo extends AbstractMojo {
-	/**
-	 * Screen width for formatting the output number of libyears
-	 */
-	private static final int INFO_PAD_SIZE = 72;
-
-	/**
-	 * Cache to store the release dates of dependencies to reduce the number of API calls to {@link #SEARCH_URI}
-	 */
-	static final Map<String, Map<String, LocalDate>> dependencyVersionReleaseDates = Maps.newHashMap();
-
-	/**
-	 * Wait until reaching the last project before executing sonar when attached to phase
-	 */
-	// TODO: Investigate setting "aggregator = true" in the @Mojo class annotation - is this necessary?
-	static final AtomicInteger readyProjectsCounter = new AtomicInteger(0);
-
-	/**
-	 * Track the running total of how many libweeks outdated we are. Used in multi-module builds.
-	 */
-	static final AtomicLong libWeeksOutDated = new AtomicLong();
-
-	/**
-	 * Track the per-project total of how many libyears outdated we are, used for maxLibYears build failures.
-	 */
-	private float projectLibYearsOutdated = 0;
-
-	/**
-	 * The Maven search URI quite often times out or returns HTTP 5xx. This variable controls how many
-	 * times we can retry on failure before skipping this dependency.
-	 */
-	private static int MAVEN_API_HTTP_RETRY_COUNT = 5;
-
-	/**
-	 * HTTP timeout for making calls to {@link #SEARCH_URI}
-	 */
-	private static int MAVEN_API_HTTP_TIMEOUT_SECONDS = 2;
-
-	/**
-	 * API endpoint to query dependency release dates for age calculations.
-	 *
-	 */
-	// TODO: Consider users requiring HTTP proxies
-	private static String SEARCH_URI = "https://search.maven.org";
-
-	private final RepositorySystem repositorySystem;
-	private final org.eclipse.aether.RepositorySystem aetherRepositorySystem;
-	private VersionsHelper helper;
-
-	/**
-	 * The Maven Project that the plugin is being executed on. Used for accessing e.g. the list of dependencies.
-	 */
-	@Parameter(defaultValue = "${project}", required = true, readonly = true)
-	private MavenProject project;
-
-	/**
-	 * The Maven Settings that are being used, e.g. ~/.m2/settings.xml.
-	 */
-	@Parameter(defaultValue = "${settings}", readonly = true)
-	private Settings settings;
-
-	@Parameter(property = "maven.version.ignore", readonly = true)
-	protected Set<String> ignoredVersions;
-
-	@Parameter(defaultValue = "${session}", required = true, readonly = true)
-	private MavenSession session;
-
-	/**
-	 * Whether to fail the build if the total number of libyears for the project exceeds this target.
-	 * <p>
-	 * In a multi-module project, this value applies to individual modules, not the parent(s).
-	 * <p>
-	 * Note: If you are using this in a project's pom.xml then you may accidentally cause issues when e.g. rebuilding
-	 * older branches. Instead, it may make more sense to use this as a command line plugin execution flag in CI or
-	 * in a Maven profile used for building releases.
-	 */
-	@Parameter(property = "maxLibYears", defaultValue = "0.0")
-	private float maxLibYears;
-
-	/**
-	 * Only take these artifacts into consideration.
-	 * <p>
-	 * Comma-separated list of extended GAV patterns.
-	 *
-	 * <p>
-	 * Extended GAV: groupId:artifactId:version:type:classifier:scope
-	 * </p>
-	 * <p>
-	 * The wildcard "*" can be used as the only, first, last or both characters in each token.
-	 * The version token does support version ranges.
-	 * </p>
-	 *
-	 * <p>
-	 * Example: {@code "mygroup:artifact:*,*:*:*:*:*:compile"}
-	 * </p>
-	 *
-	 * @since 1.0.0
-	 */
-	@Parameter(property = "pluginManagementDependencyIncludes", defaultValue = WildcardMatcher.WILDCARD)
-	private List<String> pluginManagementDependencyIncludes;
-
-	/**
-	 * <p>Exclude these artifacts into consideration:<br/>
-	 * Comma-separated list of {@code groupId:[artifactId[:version]]} patterns</p>
-	 *
-	 * <p>
-	 * The wildcard "*" can be used as the only, first, last or both characters in each token.
-	 * The version token does support version ranges.
-	 * </p>
-	 *
-	 * <p>
-	 * Example: {@code "mygroup:artifact:*,othergroup:*,anothergroup"}
-	 * </p>
-	 *
-	 * @since 1.0.0
-	 */
-	@Parameter(property = "pluginManagementDependencyExcludes")
-	private List<String> pluginManagementDependencyExcludes;
-
-	// TODO: Add test coverage for this before exposing it as an option
-	// @Parameter(property = "processDependencyManagementTransitive", defaultValue = "false")
-	// private boolean processDependencyManagementTransitive;
-	private final boolean processDependencyManagementTransitive = false;
-
-	/**
-	 * Whether to consider the dependencyManagement pom section. If this is set to false, dependencyManagement is
-	 * ignored.
-	 *
-	 * @since 1.0.
-	 */
-	@Parameter(property = "processDependencyManagement", defaultValue = "true")
-	private final boolean processDependencyManagement = true;
-
-	/**
-	 * Whether to consider the dependencies pom section. If this is set to false the plugin won't analyze dependencies,
-	 * but it might analyze e.g. plugins depending on configuration.
-	 */
-	@Parameter(property = "processDependencies", defaultValue = "true")
-	protected boolean processDependencies;
-
-	// TODO: Add test coverage for this before exposing it as an option
-	//	@Parameter(property = "processPluginDependenciesInPluginManagement", defaultValue = "true")
-	//	private boolean processPluginDependenciesInPluginManagement;
-	private final boolean processPluginDependenciesInPluginManagement = true;
-
-	// TODO: Add test coverage for this before exposing it as an option
-	//	@Parameter(property = "processPluginDependencies", defaultValue = "true")
-	//	protected boolean processPluginDependencies;
-	private final boolean processPluginDependencies = true;
-
-	/**
-	 * <p>Only take these artifacts into consideration:<br/>
-	 * Comma-separated list of {@code groupId:[artifactId[:version]]} patterns</p>
-	 *
-	 * <p>
-	 * The wildcard "*" can be used as the only, first, last or both characters in each token.
-	 * The version token does support version ranges.
-	 * </p>
-	 *
-	 * <p>
-	 * Example: {@code "mygroup:artifact:*,othergroup:*,anothergroup"}
-	 * </p>
-	 *
-	 * @since 1.0.0
-	 */
-	@Parameter(property = "pluginDependencyIncludes", defaultValue = WildcardMatcher.WILDCARD)
-	private List<String> pluginDependencyIncludes;
-
-	/**
-	 * <p>Exclude these artifacts into consideration:<br/>
-	 * Comma-separated list of {@code groupId:[artifactId[:version]]} patterns</p>
-	 *
-	 * <p>
-	 * The wildcard "*" can be used as the only, first, last or both characters in each token.
-	 * The version token does support version ranges.
-	 * </p>
-	 *
-	 * <p>
-	 * Example: {@code "mygroup:artifact:*,othergroup:*,anothergroup"}
-	 * </p>
-	 *
-	 * @since 1.0.0
-	 */
-	@Parameter(property = "pluginDependencyExcludes")
-	private List<String> pluginDependencyExcludes;
-
-	/**
-	 * Only take these artifacts into consideration.
-	 * <p>
-	 * Comma-separated list of extended GAV patterns.
-	 *
-	 * <p>
-	 * Extended GAV: groupId:artifactId:version:type:classifier:scope
-	 * </p>
-	 * <p>
-	 * The wildcard "*" can be used as the only, first, last or both characters in each token.
-	 * The version token does support version ranges.
-	 * </p>
-	 *
-	 * <p>
-	 * Example: {@code "mygroup:artifact:*,*:*:*:*:*:compile"}
-	 * </p>
-	 *
-	 * @since 1.0.0
-	 */
-	@Parameter(property = "dependencyIncludes", defaultValue = WildcardMatcher.WILDCARD)
-	private List<String> dependencyIncludes;
-
-	/**
-	 * Exclude these artifacts from consideration.
-	 * <p>
-	 * Comma-separated list of extended GAV patterns.
-	 *
-	 * <p>
-	 * Extended GAV: groupId:artifactId:version:type:classifier:scope
-	 * </p>
-	 * <p>
-	 * The wildcard "*" can be used as the only, first, last or both characters in each token.
-	 * The version token does support version ranges.
-	 * </p>
-	 *
-	 * <p>
-	 * Example: {@code "mygroup:artifact:*,*:*:*:*:*:provided,*:*:*:*:*:system"}
-	 * </p>
-	 *
-	 * @since 1.0.0
-	 */
-	@Parameter(property = "dependencyExcludes")
-	private List<String> dependencyExcludes;
-
-	/**
-	 * Only take these artifacts into consideration.
-	 * <p>
-	 * Comma-separated list of extended GAV patterns.
-	 *
-	 * <p>
-	 * Extended GAV: groupId:artifactId:version:type:classifier:scope
-	 * </p>
-	 * <p>
-	 * The wildcard "*" can be used as the only, first, last or both characters in each token.
-	 * The version token does support version ranges.
-	 * </p>
-	 *
-	 * <p>
-	 * Example: {@code "mygroup:artifact:*,*:*:*:*:*:compile"}
-	 * </p>
-	 *
-	 * @since 1.0.0
-	 */
-	@Parameter(property = "dependencyManagementIncludes", defaultValue = WildcardMatcher.WILDCARD)
-	private List<String> dependencyManagementIncludes;
-
-	/**
-	 * Exclude these artifacts from consideration.
-	 * <p>
-	 * Comma-separated list of extended GAV patterns.
-	 *
-	 * <p>
-	 * Extended GAV: groupId:artifactId:version:type:classifier:scope
-	 * </p>
-	 * <p>
-	 * The wildcard "*" can be used as the only, first, last or both characters in each token.
-	 * The version token does support version ranges.
-	 * </p>
-	 *
-	 * <p>
-	 * Example: {@code "mygroup:artifact:*,*:*:*:*:*:provided,*:*:*:*:*:system"}
-	 * </p>
-	 *
-	 * @since 1.0.0
-	 */
-	@Parameter(property = "dependencyManagementExcludes")
-	private List<String> dependencyManagementExcludes;
-
-	@Inject
-	public LibYearMojo(RepositorySystem repositorySystem,
-					   org.eclipse.aether.RepositorySystem aetherRepositorySystem) {
-		this.repositorySystem = repositorySystem;
-		this.aetherRepositorySystem = aetherRepositorySystem;
-	}
-
-	/**
-	 * Setter for property 'project'.
-	 *
-	 * @param project Value to set for property 'project'.
-	 */
-	protected void setProject(MavenProject project) {
-		this.project = project;
-	}
-
-	/**
-	 * Setter for property 'session'.
-	 *
-	 * @param session Value to set for property 'session'.
-	 */
-	protected void setSession(MavenSession session) {
-		this.session = session;
-	}
-
-	/**
-	 * Set the search URI
-	 */
-	protected void setSearchUri(String uri) {
-		SEARCH_URI = uri;
-	}
-
-	/**
-	 * Setter for the HTTP timeout for API calls
-	 */
-	protected void setHttpTimeout(int seconds) {
-		MAVEN_API_HTTP_TIMEOUT_SECONDS = seconds;
-	}
-
-	/**
-	 * Setter for the HTTP API fetch retry count
-	 * @param count	the number of retries before giving up
-	 */
-	protected void setFetchRetryCount(int count) { MAVEN_API_HTTP_RETRY_COUNT = count; }
-
-	/**
-	 * Check if the mojo is configured to consider dependencyManagement
-	 *
-	 * @return	whether the mojo is configured to consider dependencyManagement
-	 */
-	public boolean isProcessingDependencyManagement() {
-		return processDependencyManagement;
-	}
-
-	/**
-	 * Check if the mojo is configured to consider dependencies
-	 *
-	 * @return	whether the mojo is configured to consider dependencies
-	 */
-	public boolean isProcessingDependencies() {
-		return processDependencies;
-	}
-
-	/**
-	 * Check if the mojo is configured to consider dependencies of plugins
-	 *
-	 * @return	whether the mojo is configured to consider plugin dependencies
-	 */
-	public boolean isProcessingPluginDependencies() {
-		return processPluginDependencies;
-	}
-
-	/**
-	 * Check if the mojo is configured to consider dependencies of plugins that are overridden in dependencyManagement
-	 *
-	 * @return	whether the mojo is configured to consider plugin dependencies that are overridden in dependencyManagement
-	 */
-	public boolean isProcessPluginDependenciesInDependencyManagement() {
-		return processPluginDependenciesInPluginManagement;
-	}
-
-	// TODO: This is stolen from DisplayDependencyUpdatesMojo
-	private static boolean dependenciesMatch(Dependency dependency, Dependency managedDependency) {
-		if (!managedDependency.getGroupId().equals(dependency.getGroupId())) {
-			return false;
-		}
-
-		if (!managedDependency.getArtifactId().equals(dependency.getArtifactId())) {
-			return false;
-		}
-
-		if (managedDependency.getScope() == null
-				|| Objects.equals(managedDependency.getScope(), dependency.getScope())) {
-			return false;
-		}
-
-		if (managedDependency.getClassifier() == null
-				|| Objects.equals(managedDependency.getClassifier(), dependency.getClassifier())) {
-			return false;
-		}
-
-		return dependency.getVersion() == null
-				|| managedDependency.getVersion() == null
-				|| Objects.equals(managedDependency.getVersion(), dependency.getVersion());
-	}
-
-	/**
-	 * Main entry point for the plugin.
-	 *
-	 * @throws MojoExecutionException	On failure, such as upstream HTTP issues
-	 */
-	public void execute() throws MojoExecutionException {
-		Set<Dependency> dependencyManagement = emptySet();
-
-		try {
-			if (isProcessingDependencyManagement()) {
-				dependencyManagement = filterDependencies(extractDependenciesFromDependencyManagement(project,
-								processDependencyManagementTransitive, getLog()),
-						dependencyManagementIncludes, dependencyManagementExcludes, "Dependency Management",
-						getLog());
-
-				logUpdates(getHelper().lookupDependenciesUpdates(dependencyManagement,
-						false, false), "Dependency Management");
-			}
-			if (isProcessingDependencies()) {
-				Set<Dependency> finalDependencyManagement = dependencyManagement;
-				logUpdates(getHelper().lookupDependenciesUpdates(
-								filterDependencies(project.getDependencies()
-												.parallelStream()
-												.filter(dep -> finalDependencyManagement.parallelStream()
-														.noneMatch(depMan -> dependenciesMatch(dep, depMan)))
-												.collect(() -> new TreeSet<>(DependencyComparator.INSTANCE), Set::add, Set::addAll),
-										dependencyIncludes, dependencyExcludes, "Dependencies", getLog()),
-								false, false),
-						"Dependencies");
-			}
-			if (isProcessPluginDependenciesInDependencyManagement()) {
-				logUpdates(getHelper().lookupDependenciesUpdates(filterDependencies(
-								MavenProjectUtils.extractPluginDependenciesFromPluginsInPluginManagement(project),
-								pluginManagementDependencyIncludes, pluginManagementDependencyExcludes,
-								"Plugin Management Dependencies", getLog()), false, false),
-						"pluginManagement of plugins");
-			}
-			if (isProcessingPluginDependencies()) {
-				logUpdates(getHelper().lookupDependenciesUpdates(filterDependencies(
-								MavenProjectUtils.extractDependenciesFromPlugins(project),
-								pluginDependencyIncludes, pluginDependencyExcludes, "Plugin Dependencies",
-								getLog()), false, false),
-						"Plugin Dependencies");
-			}
-
-			if (isLastProjectInReactor() && readyProjectsCounter.get() != 1) {
-				// If there's more than one project in the tree, show the summary
-				getLog().info(String.format("Total years for entire project: %.2f", libWeeksOutDated.get() / 52f));
-			}
-		} catch (Exception e) {
-			throw new MojoExecutionException(e.getMessage(), e);
-		}
-	}
-
-	private VersionsHelper getHelper() throws MojoExecutionException {
-		if (helper == null) {
-			helper = new DefaultVersionsHelper.Builder()
-					.withRepositorySystem(repositorySystem)
-					.withAetherRepositorySystem(aetherRepositorySystem)
-					.withIgnoredVersions(ignoredVersions)
-					.withLog(getLog())
-					.withMavenSession(session)
-					.build();
-		}
-		return helper;
-	}
-
-	/**
-	 *
-	 * @param updates
-	 * @param section
-	 */
-	private void logUpdates(Map<Dependency, ArtifactVersions> updates, String section) throws MojoExecutionException {
-		Map<String, Pair<LocalDate, LocalDate>> dependencyVersionUpdates = Maps.newHashMap();
-
-		for (ArtifactVersions versions : updates.values()) {
-			final String current;
-			ArtifactVersion latest;
-			if (versions.isCurrentVersionDefined()) {
-				current = versions.getCurrentVersion().toString();
-				latest = versions.getNewestUpdate(Optional.empty(), false);
-			} else {
-				ArtifactVersion newestVersion =
-						versions.getNewestVersion(versions.getArtifact().getVersionRange(), false);
-				current = versions.getArtifact().getVersionRange().toString();
-				latest = newestVersion == null ? null
-						: versions.getNewestUpdate(newestVersion, Optional.empty(), false);
-				if (latest != null
-						&& ArtifactVersions.isVersionInRange(latest, versions.getArtifact().getVersionRange())) {
-					latest = null;
-				}
-			}
-
-			if (latest == null) {
-				continue;
-			}
-
-			if (current.equals(latest.toString())) {
-				continue;
-			}
-
-			// TODO: Maven mirrors?
-			Artifact /* current */ artifact = versions.getArtifact();
-			Optional<LocalDate> latestVersionReleaseDate = getReleaseDate(artifact.getGroupId(), artifact.getArtifactId(),
-					latest.toString());
-			Optional<LocalDate> currentVersionReleaseDate = getReleaseDate(artifact.getGroupId(), artifact.getArtifactId(),
-					current);
-
-			if (latestVersionReleaseDate.isEmpty() || currentVersionReleaseDate.isEmpty()) {
-				// We couldn't find version details, skip
-				continue;
-			}
-
-			dependencyVersionUpdates.put(artifact.getGroupId() + ":" + artifact.getArtifactId(), Pair.of(currentVersionReleaseDate.get(),
-					latestVersionReleaseDate.get()));
-		}
-
-		float yearsOutdated = 0;
-		if (!dependencyVersionUpdates.isEmpty()) {
-			yearsOutdated = logDependencyUpdates(section, dependencyVersionUpdates);
-		}
-
-		projectLibYearsOutdated += yearsOutdated;
-
-		// Total: Show this across the entire project, not just per section
-		if (yearsOutdated != 0f) {
-			getLog().info(String.format("Total years outdated: %.2f", yearsOutdated));
-		}
-
-		if (maxLibYears != 0 && projectLibYearsOutdated >= maxLibYears) {
-			getLog().info("");
-			getLog().error("This project exceeds the maximum dependency age of " + maxLibYears + " libyears.");
-			throw new MojoExecutionException("Dependencies exceed maximum specified age in libyears");
-		}
-	}
-
-	/**
-	 * Given a set of outdated dependencies, print how many libyears outdated they are to the screen.
-	 *
-	 * @param pomSection	The section of the pom we are analyzing
-	 * @param outdatedDependencies	The outdated dependencies
-	 * @return	A total libyear count for the provided dependencies
-	 */
-	private float logDependencyUpdates(String pomSection, Map<String, Pair<LocalDate, LocalDate>> outdatedDependencies) {
-		float[] yearsOutdated = {0};
-
-		getLog().info("");
-		getLog().info("The following dependencies in " + pomSection + " have newer versions:");
-		outdatedDependencies
-				.entrySet()
-				.stream().sorted(Map.Entry.comparingByKey())
-				.forEach((dep) -> {
-			LocalDate currentReleaseDate = dep.getValue().getLeft();
-			LocalDate latestReleaseDate = dep.getValue().getRight();
-
-			if (currentReleaseDate.isAfter(latestReleaseDate)) {
-				// This is a bug in the underlying logic, where the display-dependency-updates plugin will include
-				// updates from e.g commons-io:commons-io 2.11.0 -> 20030203.000550, despite 2.11.0 being ~15 years
-				// newer. We return here so we don't count a negative libyear count, even though the dependency may
-				// still be outdated.
-
-				// Anybody experiencing this could use the ignoredVersions setting instead
-				return;
-			}
-
-			long libWeeksOutdated = ChronoUnit.WEEKS.between(currentReleaseDate, latestReleaseDate);
-			float libYearsOutdated = libWeeksOutdated / 52f;
-
-			String right = String.format(" %.2f libyears", libYearsOutdated);
-			String left = "  " + dep.getKey() + " ";
-
-			// TODO Handle when the name is very long
-
-			String versionWithDots = StringUtils.rightPad(left, INFO_PAD_SIZE - right.length(), ".");
-
-			getLog().info(versionWithDots + right);
-			yearsOutdated[0] += libYearsOutdated;
-			libWeeksOutDated.getAndAdd(libWeeksOutdated);
-		});
-
-		getLog().info("");
-
-		return yearsOutdated[0];
-	}
-
-	/**
-	 * Make an API call to {@link #SEARCH_URI} to fetch the release date of the specified artifact. Uses the cache in
-	 * {@link #dependencyVersionReleaseDates} if possible.
-	 *
-	 * @param groupId	The required artifact's groupId
-	 * @param artifactId	The required artifact's artifactId
-	 * @param version	The required artifact's version
-	 * @return	The creation date of the artifact
-	 */
-	private Optional<LocalDate> getReleaseDate(String groupId, String artifactId, String version) {
-		String ga = groupId + ":" + artifactId;
-		Map<String, LocalDate> versionReleaseDates = dependencyVersionReleaseDates.getOrDefault(ga, Maps.newHashMap());
-		if (versionReleaseDates.containsKey(version)) {
-			return Optional.of(versionReleaseDates.get(version));
-		}
-
-		try {
-			Optional<String> response = fetchReleaseDate(groupId, artifactId, version);
-
-			if (response.isEmpty()) {
-				// TODO: Duplicate code
-				return Optional.empty();
-			}
-
-			JSONObject json = new JSONObject(response.get());
-			JSONObject queryResponse = json.getJSONObject("response");
-			if (queryResponse.getLong("numFound") != 0) {
-				long epochTime = queryResponse.getJSONArray("docs").getJSONObject(0).getLong("timestamp");
-
-				getLog().debug("Found release time " + epochTime + " for " + groupId + ":" + artifactId + ":" + version);
-				LocalDate releaseDate = Instant.ofEpochMilli(epochTime).atZone(ZoneId.systemDefault()).toLocalDate();
-
-				versionReleaseDates.put(version, releaseDate);
-				dependencyVersionReleaseDates.put(ga, versionReleaseDates);
-				return Optional.of(releaseDate);
-			} else {
-				getLog().debug("Could not find artifact for " + groupId + ":" + artifactId + " " + version);
-				return Optional.empty();
-			}
-		} catch (Exception e) {
-			getLog().error(String.format("Failed to fetch release date for %s %s: %s", ga, version, e.getMessage()));
-			return Optional.empty();
-		}
-	}
-
-	/**
-	 * Make the API call to fetch the release date
-	 */
-	private Optional<String> fetchReleaseDate(String groupId, String artifactId, String version) throws IOException {
-		URI artifactUri = URI.create(String.format("%s/solrsearch/select?q=g:%s+AND+a:%s+AND+v:%s&wt=json", SEARCH_URI, groupId, artifactId, version));
-
-		getLog().debug("Fetching " + artifactUri);
-
-		RequestConfig config = RequestConfig.custom()
-				.setConnectTimeout(MAVEN_API_HTTP_TIMEOUT_SECONDS * 1000)
-				.setConnectionRequestTimeout(MAVEN_API_HTTP_TIMEOUT_SECONDS * 1000)
-				.setSocketTimeout(MAVEN_API_HTTP_TIMEOUT_SECONDS * 1000)
-				.build();
-
-		try (CloseableHttpClient httpClient = HttpClientBuilder.create()
-				.setDefaultRequestConfig(config)
-				.addInterceptorLast((HttpResponseInterceptor) (response, context) -> {
-					// By default Apache HTTP client doesn't retry on 5xx errors
-					if (response.getStatusLine().getStatusCode() >= 500) {
-						throw new IOException(response.getStatusLine().getReasonPhrase());
-					}
-				})
-				.setRetryHandler(new RetryAllExceptionsLoggingHandler(getLog(), MAVEN_API_HTTP_RETRY_COUNT, true))
-				.build()) {
-			final HttpGet httpGet = new HttpGet(artifactUri);
-
-			try (CloseableHttpResponse response = httpClient.execute(httpGet)) {
-				if (response.getStatusLine().getStatusCode() != 200) {
-					getLog().error(String.format("Failed to fetch release date for %s:%s %s (%s)", groupId, artifactId, version, response.getStatusLine().getReasonPhrase()));
-					return Optional.empty();
-				}
-
-				String responseBody = EntityUtils.toString(response.getEntity(), StandardCharsets.UTF_8);
-				return Optional.of(responseBody);
-			} catch (ConnectTimeoutException | SocketTimeoutException e) {
-				getLog().error(String.format("Failed to fetch release date for %s:%s %s (%s)", groupId, artifactId, version, "request timed out"));
-				return Optional.empty();
-			}
-		}
-	}
-
-	/**
-	 * Calculate if this is the last project in a multi-project pom. This is used to show a total "libyears outdated"
-	 * figure for this project and all child projects.
-	 *
-	 * @return Whether this is the last project to be analysed by the plugin
-	 */
-	private boolean isLastProjectInReactor() {
-		return readyProjectsCounter.incrementAndGet() != session.getProjects().size();
-	}
-
-	private static class RetryAllExceptionsLoggingHandler extends DefaultHttpRequestRetryHandler {
-		Log logger;
-
-		/**
-		 * The superclass has a third constructor parameter listing Exception classes to not retry on, this
-		 * class just passes an empty list. It also logs each retry.
-		 *
-		 * @param logger
-		 * @param retryCount
-		 * @param requestSentRetryEnabled
-		 */
-		public RetryAllExceptionsLoggingHandler(Log logger, int retryCount, boolean requestSentRetryEnabled) {
-			super(retryCount, requestSentRetryEnabled, new ArrayList<>());
-			this.logger = logger;
-		}
-
-		@Override
-		public boolean retryRequest(IOException exception, int executionCount, HttpContext context) {
-			logger.debug("Retrying count " + executionCount);
-			return super.retryRequest(exception, executionCount, context);
-		}
-	}
+    /** Screen width for formatting the output number of libyears */
+    private static final int INFO_PAD_SIZE = 72;
+
+    /**
+     * Cache to store the release dates of dependencies to reduce the number of API calls to {@link
+     * #SEARCH_URI}
+     */
+    static final Map<String, Map<String, LocalDate>> dependencyVersionReleaseDates = Maps.newHashMap();
+
+    /** Wait until reaching the last project before executing sonar when attached to phase */
+    // TODO: Investigate setting "aggregator = true" in the @Mojo class annotation -
+    // is this
+    // necessary?
+    static final AtomicInteger readyProjectsCounter = new AtomicInteger(0);
+
+    /**
+     * Track the running total of how many libweeks outdated we are. Used in multi-module builds.
+     */
+    static final AtomicLong libWeeksOutDated = new AtomicLong();
+
+    /**
+     * Track the per-project total of how many libyears outdated we are, used for maxLibYears build
+     * failures.
+     */
+    private float projectLibYearsOutdated = 0;
+
+    /**
+     * The Maven search URI quite often times out or returns HTTP 5xx. This variable controls how
+     * many times we can retry on failure before skipping this dependency.
+     */
+    private static int MAVEN_API_HTTP_RETRY_COUNT = 5;
+
+    /** HTTP timeout for making calls to {@link #SEARCH_URI} */
+    private static int MAVEN_API_HTTP_TIMEOUT_SECONDS = 2;
+
+    /** API endpoint to query dependency release dates for age calculations. */
+    // TODO: Consider users requiring HTTP proxies
+    private static String SEARCH_URI = "https://search.maven.org";
+
+    private final RepositorySystem repositorySystem;
+    private final org.eclipse.aether.RepositorySystem aetherRepositorySystem;
+    private VersionsHelper helper;
+
+    /**
+     * The Maven Project that the plugin is being executed on. Used for accessing e.g. the list of
+     * dependencies.
+     */
+    @Parameter(defaultValue = "${project}", required = true, readonly = true)
+    private MavenProject project;
+
+    /** The Maven Settings that are being used, e.g. ~/.m2/settings.xml. */
+    @Parameter(defaultValue = "${settings}", readonly = true)
+    private Settings settings;
+
+    @Parameter(property = "maven.version.ignore", readonly = true)
+    protected Set<String> ignoredVersions;
+
+    @Parameter(defaultValue = "${session}", required = true, readonly = true)
+    private MavenSession session;
+
+    /**
+     * Whether to fail the build if the total number of libyears for the project exceeds this
+     * target.
+     *
+     * <p>In a multi-module project, this value applies to individual modules, not the parent(s).
+     *
+     * <p>Note: If you are using this in a project's pom.xml then you may accidentally cause issues
+     * when e.g. rebuilding older branches. Instead, it may make more sense to use this as a command
+     * line plugin execution flag in CI or in a Maven profile used for building releases.
+     */
+    @Parameter(property = "maxLibYears", defaultValue = "0.0")
+    private float maxLibYears;
+
+    /**
+     * Only take these artifacts into consideration.
+     *
+     * <p>Comma-separated list of extended GAV patterns.
+     *
+     * <p>Extended GAV: groupId:artifactId:version:type:classifier:scope
+     *
+     * <p>The wildcard "*" can be used as the only, first, last or both characters in each token.
+     * The version token does support version ranges.
+     *
+     * <p>Example: {@code "mygroup:artifact:*,*:*:*:*:*:compile"}
+     *
+     * @since 1.0.0
+     */
+    @Parameter(property = "pluginManagementDependencyIncludes", defaultValue = WildcardMatcher.WILDCARD)
+    private List<String> pluginManagementDependencyIncludes;
+
+    /**
+     * Exclude these artifacts into consideration:<br>
+     * Comma-separated list of {@code groupId:[artifactId[:version]]} patterns
+     *
+     * <p>The wildcard "*" can be used as the only, first, last or both characters in each token.
+     * The version token does support version ranges.
+     *
+     * <p>Example: {@code "mygroup:artifact:*,othergroup:*,anothergroup"}
+     *
+     * @since 1.0.0
+     */
+    @Parameter(property = "pluginManagementDependencyExcludes")
+    private List<String> pluginManagementDependencyExcludes;
+
+    // TODO: Add test coverage for this before exposing it as an option
+    // @Parameter(property = "processDependencyManagementTransitive", defaultValue =
+    // "false")
+    // private boolean processDependencyManagementTransitive;
+    private final boolean processDependencyManagementTransitive = false;
+
+    /**
+     * Whether to consider the dependencyManagement pom section. If this is set to false,
+     * dependencyManagement is ignored.
+     *
+     * @since 1.0.
+     */
+    @Parameter(property = "processDependencyManagement", defaultValue = "true")
+    private final boolean processDependencyManagement = true;
+
+    /**
+     * Whether to consider the dependencies pom section. If this is set to false the plugin won't
+     * analyze dependencies, but it might analyze e.g. plugins depending on configuration.
+     */
+    @Parameter(property = "processDependencies", defaultValue = "true")
+    protected boolean processDependencies;
+
+    // TODO: Add test coverage for this before exposing it as an option
+    // @Parameter(property = "processPluginDependenciesInPluginManagement",
+    // defaultValue = "true")
+    // private boolean processPluginDependenciesInPluginManagement;
+    private final boolean processPluginDependenciesInPluginManagement = true;
+
+    // TODO: Add test coverage for this before exposing it as an option
+    // @Parameter(property = "processPluginDependencies", defaultValue = "true")
+    // protected boolean processPluginDependencies;
+    private final boolean processPluginDependencies = true;
+
+    /**
+     * Only take these artifacts into consideration:<br>
+     * Comma-separated list of {@code groupId:[artifactId[:version]]} patterns
+     *
+     * <p>The wildcard "*" can be used as the only, first, last or both characters in each token.
+     * The version token does support version ranges.
+     *
+     * <p>Example: {@code "mygroup:artifact:*,othergroup:*,anothergroup"}
+     *
+     * @since 1.0.0
+     */
+    @Parameter(property = "pluginDependencyIncludes", defaultValue = WildcardMatcher.WILDCARD)
+    private List<String> pluginDependencyIncludes;
+
+    /**
+     * Exclude these artifacts into consideration:<br>
+     * Comma-separated list of {@code groupId:[artifactId[:version]]} patterns
+     *
+     * <p>The wildcard "*" can be used as the only, first, last or both characters in each token.
+     * The version token does support version ranges.
+     *
+     * <p>Example: {@code "mygroup:artifact:*,othergroup:*,anothergroup"}
+     *
+     * @since 1.0.0
+     */
+    @Parameter(property = "pluginDependencyExcludes")
+    private List<String> pluginDependencyExcludes;
+
+    /**
+     * Only take these artifacts into consideration.
+     *
+     * <p>Comma-separated list of extended GAV patterns.
+     *
+     * <p>Extended GAV: groupId:artifactId:version:type:classifier:scope
+     *
+     * <p>The wildcard "*" can be used as the only, first, last or both characters in each token.
+     * The version token does support version ranges.
+     *
+     * <p>Example: {@code "mygroup:artifact:*,*:*:*:*:*:compile"}
+     *
+     * @since 1.0.0
+     */
+    @Parameter(property = "dependencyIncludes", defaultValue = WildcardMatcher.WILDCARD)
+    private List<String> dependencyIncludes;
+
+    /**
+     * Exclude these artifacts from consideration.
+     *
+     * <p>Comma-separated list of extended GAV patterns.
+     *
+     * <p>Extended GAV: groupId:artifactId:version:type:classifier:scope
+     *
+     * <p>The wildcard "*" can be used as the only, first, last or both characters in each token.
+     * The version token does support version ranges.
+     *
+     * <p>Example: {@code "mygroup:artifact:*,*:*:*:*:*:provided,*:*:*:*:*:system"}
+     *
+     * @since 1.0.0
+     */
+    @Parameter(property = "dependencyExcludes")
+    private List<String> dependencyExcludes;
+
+    /**
+     * Only take these artifacts into consideration.
+     *
+     * <p>Comma-separated list of extended GAV patterns.
+     *
+     * <p>Extended GAV: groupId:artifactId:version:type:classifier:scope
+     *
+     * <p>The wildcard "*" can be used as the only, first, last or both characters in each token.
+     * The version token does support version ranges.
+     *
+     * <p>Example: {@code "mygroup:artifact:*,*:*:*:*:*:compile"}
+     *
+     * @since 1.0.0
+     */
+    @Parameter(property = "dependencyManagementIncludes", defaultValue = WildcardMatcher.WILDCARD)
+    private List<String> dependencyManagementIncludes;
+
+    /**
+     * Exclude these artifacts from consideration.
+     *
+     * <p>Comma-separated list of extended GAV patterns.
+     *
+     * <p>Extended GAV: groupId:artifactId:version:type:classifier:scope
+     *
+     * <p>The wildcard "*" can be used as the only, first, last or both characters in each token.
+     * The version token does support version ranges.
+     *
+     * <p>Example: {@code "mygroup:artifact:*,*:*:*:*:*:provided,*:*:*:*:*:system"}
+     *
+     * @since 1.0.0
+     */
+    @Parameter(property = "dependencyManagementExcludes")
+    private List<String> dependencyManagementExcludes;
+
+    @Inject
+    public LibYearMojo(RepositorySystem repositorySystem, org.eclipse.aether.RepositorySystem aetherRepositorySystem) {
+        this.repositorySystem = repositorySystem;
+        this.aetherRepositorySystem = aetherRepositorySystem;
+    }
+
+    /**
+     * Setter for property 'project'.
+     *
+     * @param project Value to set for property 'project'.
+     */
+    protected void setProject(MavenProject project) {
+        this.project = project;
+    }
+
+    /**
+     * Setter for property 'session'.
+     *
+     * @param session Value to set for property 'session'.
+     */
+    protected void setSession(MavenSession session) {
+        this.session = session;
+    }
+
+    /** Set the search URI */
+    protected void setSearchUri(String uri) {
+        SEARCH_URI = uri;
+    }
+
+    /** Setter for the HTTP timeout for API calls */
+    protected void setHttpTimeout(int seconds) {
+        MAVEN_API_HTTP_TIMEOUT_SECONDS = seconds;
+    }
+
+    /**
+     * Setter for the HTTP API fetch retry count
+     *
+     * @param count the number of retries before giving up
+     */
+    protected void setFetchRetryCount(int count) {
+        MAVEN_API_HTTP_RETRY_COUNT = count;
+    }
+
+    /**
+     * Check if the mojo is configured to consider dependencyManagement
+     *
+     * @return whether the mojo is configured to consider dependencyManagement
+     */
+    public boolean isProcessingDependencyManagement() {
+        return processDependencyManagement;
+    }
+
+    /**
+     * Check if the mojo is configured to consider dependencies
+     *
+     * @return whether the mojo is configured to consider dependencies
+     */
+    public boolean isProcessingDependencies() {
+        return processDependencies;
+    }
+
+    /**
+     * Check if the mojo is configured to consider dependencies of plugins
+     *
+     * @return whether the mojo is configured to consider plugin dependencies
+     */
+    public boolean isProcessingPluginDependencies() {
+        return processPluginDependencies;
+    }
+
+    /**
+     * Check if the mojo is configured to consider dependencies of plugins that are overridden in
+     * dependencyManagement
+     *
+     * @return whether the mojo is configured to consider plugin dependencies that are overridden in
+     *     dependencyManagement
+     */
+    public boolean isProcessPluginDependenciesInDependencyManagement() {
+        return processPluginDependenciesInPluginManagement;
+    }
+
+    // TODO: This is stolen from DisplayDependencyUpdatesMojo
+    private static boolean dependenciesMatch(Dependency dependency, Dependency managedDependency) {
+        if (!managedDependency.getGroupId().equals(dependency.getGroupId())) {
+            return false;
+        }
+
+        if (!managedDependency.getArtifactId().equals(dependency.getArtifactId())) {
+            return false;
+        }
+
+        if (managedDependency.getScope() == null
+                || Objects.equals(managedDependency.getScope(), dependency.getScope())) {
+            return false;
+        }
+
+        if (managedDependency.getClassifier() == null
+                || Objects.equals(managedDependency.getClassifier(), dependency.getClassifier())) {
+            return false;
+        }
+
+        return dependency.getVersion() == null
+                || managedDependency.getVersion() == null
+                || Objects.equals(managedDependency.getVersion(), dependency.getVersion());
+    }
+
+    /**
+     * Main entry point for the plugin.
+     *
+     * @throws MojoExecutionException On failure, such as upstream HTTP issues
+     */
+    public void execute() throws MojoExecutionException {
+        Set<Dependency> dependencyManagement = emptySet();
+
+        try {
+            if (isProcessingDependencyManagement()) {
+                Set<Dependency> dependenciesFromDependencyManagement = extractDependenciesFromDependencyManagement(
+                        project, processDependencyManagementTransitive, getLog());
+
+                dependencyManagement = filterDependencies(
+                        dependenciesFromDependencyManagement,
+                        dependencyManagementIncludes,
+                        dependencyManagementExcludes,
+                        "Dependency Management",
+                        getLog());
+
+                logUpdates(
+                        getHelper().lookupDependenciesUpdates(dependencyManagement, false, false),
+                        "Dependency Management");
+            }
+            if (isProcessingDependencies()) {
+                Set<Dependency> finalDependencyManagement = dependencyManagement;
+
+                Set<Dependency> dependenciesExcludingOverriden = project.getDependencies().parallelStream()
+                        .filter(dep -> finalDependencyManagement.parallelStream()
+                                .noneMatch(depMan -> dependenciesMatch(dep, depMan)))
+                        .collect(() -> new TreeSet<>(DependencyComparator.INSTANCE), Set::add, Set::addAll);
+
+                Set<Dependency> dependencies = filterDependencies(
+                        dependenciesExcludingOverriden,
+                        dependencyIncludes,
+                        dependencyExcludes,
+                        "Dependencies",
+                        getLog());
+
+                logUpdates(getHelper().lookupDependenciesUpdates(dependencies, false, false), "Dependencies");
+            }
+            if (isProcessPluginDependenciesInDependencyManagement()) {
+                Set<Dependency> pluginDependenciesFromDepManagement =
+                        extractPluginDependenciesFromPluginsInPluginManagement(project);
+
+                Set<Dependency> filteredPluginDependenciesFromDepManagement = filterDependencies(
+                        pluginDependenciesFromDepManagement,
+                        pluginManagementDependencyIncludes,
+                        pluginManagementDependencyExcludes,
+                        "Plugin Management Dependencies",
+                        getLog());
+                logUpdates(
+                        getHelper()
+                                .lookupDependenciesUpdates(filteredPluginDependenciesFromDepManagement, false, false),
+                        "pluginManagement of plugins");
+            }
+            if (isProcessingPluginDependencies()) {
+                Set<Dependency> filteredPluginDependencies = filterDependencies(
+                        extractDependenciesFromPlugins(project),
+                        pluginDependencyIncludes,
+                        pluginDependencyExcludes,
+                        "Plugin Dependencies",
+                        getLog());
+
+                logUpdates(
+                        getHelper().lookupDependenciesUpdates(filteredPluginDependencies, false, false),
+                        "Plugin Dependencies");
+            }
+
+            if (isLastProjectInReactor() && readyProjectsCounter.get() != 1) {
+                // If there's more than one project in the tree, show the summary
+                getLog().info(String.format("Total years for entire project: %.2f", libWeeksOutDated.get() / 52f));
+            }
+        } catch (Exception e) {
+            throw new MojoExecutionException(e.getMessage(), e);
+        }
+    }
+
+    private VersionsHelper getHelper() throws MojoExecutionException {
+        if (helper == null) {
+            helper = new DefaultVersionsHelper.Builder()
+                    .withRepositorySystem(repositorySystem)
+                    .withAetherRepositorySystem(aetherRepositorySystem)
+                    .withIgnoredVersions(ignoredVersions)
+                    .withLog(getLog())
+                    .withMavenSession(session)
+                    .build();
+        }
+        return helper;
+    }
+
+    /**
+     * @param updates
+     * @param section
+     */
+    private void logUpdates(Map<Dependency, ArtifactVersions> updates, String section) throws MojoExecutionException {
+        Map<String, Pair<LocalDate, LocalDate>> dependencyVersionUpdates = Maps.newHashMap();
+
+        for (ArtifactVersions versions : updates.values()) {
+            final String current;
+            ArtifactVersion latest;
+            if (versions.isCurrentVersionDefined()) {
+                current = versions.getCurrentVersion().toString();
+                latest = versions.getNewestUpdate(Optional.empty(), false);
+            } else {
+                ArtifactVersion newestVersion =
+                        versions.getNewestVersion(versions.getArtifact().getVersionRange(), false);
+                current = versions.getArtifact().getVersionRange().toString();
+                latest =
+                        newestVersion == null ? null : versions.getNewestUpdate(newestVersion, Optional.empty(), false);
+                if (latest != null
+                        && ArtifactVersions.isVersionInRange(
+                                latest, versions.getArtifact().getVersionRange())) {
+                    latest = null;
+                }
+            }
+
+            if (latest == null) {
+                continue;
+            }
+
+            if (current.equals(latest.toString())) {
+                continue;
+            }
+
+            // TODO: Maven mirrors?
+            Artifact /* current */ artifact = versions.getArtifact();
+            Optional<LocalDate> latestVersionReleaseDate =
+                    getReleaseDate(artifact.getGroupId(), artifact.getArtifactId(), latest.toString());
+            Optional<LocalDate> currentVersionReleaseDate =
+                    getReleaseDate(artifact.getGroupId(), artifact.getArtifactId(), current);
+
+            if (latestVersionReleaseDate.isEmpty() || currentVersionReleaseDate.isEmpty()) {
+                // We couldn't find version details, skip
+                continue;
+            }
+
+            dependencyVersionUpdates.put(
+                    artifact.getGroupId() + ":" + artifact.getArtifactId(),
+                    Pair.of(currentVersionReleaseDate.get(), latestVersionReleaseDate.get()));
+        }
+
+        float yearsOutdated = 0;
+        if (!dependencyVersionUpdates.isEmpty()) {
+            yearsOutdated = logDependencyUpdates(section, dependencyVersionUpdates);
+        }
+
+        projectLibYearsOutdated += yearsOutdated;
+
+        // Total: Show this across the entire project, not just per section
+        if (yearsOutdated != 0f) {
+            getLog().info(String.format("Total years outdated: %.2f", yearsOutdated));
+        }
+
+        if (maxLibYears != 0 && projectLibYearsOutdated >= maxLibYears) {
+            getLog().info("");
+            getLog().error("This project exceeds the maximum dependency age of " + maxLibYears + " libyears.");
+            throw new MojoExecutionException("Dependencies exceed maximum specified age in libyears");
+        }
+    }
+
+    /**
+     * Given a set of outdated dependencies, print how many libyears outdated they are to the
+     * screen.
+     *
+     * @param pomSection The section of the pom we are analyzing
+     * @param outdatedDependencies The outdated dependencies
+     * @return A total libyear count for the provided dependencies
+     */
+    private float logDependencyUpdates(
+            String pomSection, Map<String, Pair<LocalDate, LocalDate>> outdatedDependencies) {
+        if (outdatedDependencies.isEmpty()) {
+            return 0.0f;
+        }
+
+        Map<String, Pair<LocalDate, LocalDate>> validOutdatedDependencies = outdatedDependencies.entrySet().stream()
+                .filter((dep) -> {
+                    LocalDate currentReleaseDate = dep.getValue().getLeft();
+                    LocalDate latestReleaseDate = dep.getValue().getRight();
+
+                    // This is a bug in the underlying logic, where the
+                    // display-dependency-updates plugin will include
+                    // updates from e.g commons-io:commons-io 2.11.0 ->
+                    // 20030203.000550, despite 2.11.0 being ~15 years
+                    // newer. We return here so we don't count a negative
+                    // libyear count, even though the dependency may still be
+                    // outdated. Anybody experiencing this could use the
+                    // ignoredVersions setting instead
+                    return !currentReleaseDate.isAfter(latestReleaseDate);
+                })
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+
+        if (validOutdatedDependencies.isEmpty()) {
+            return 0.0f;
+        }
+
+        float[] yearsOutdated = {0};
+
+        getLog().info("");
+        getLog().info("The following dependencies in " + pomSection + " have newer versions:");
+        validOutdatedDependencies.entrySet().stream()
+                .sorted(Map.Entry.comparingByKey())
+                .forEach((dep) -> {
+                    LocalDate currentReleaseDate = dep.getValue().getLeft();
+                    LocalDate latestReleaseDate = dep.getValue().getRight();
+
+                    long libWeeksOutdated = ChronoUnit.WEEKS.between(currentReleaseDate, latestReleaseDate);
+                    float libYearsOutdated = libWeeksOutdated / 52f;
+
+                    String right = String.format(" %.2f libyears", libYearsOutdated);
+                    String left = "  " + dep.getKey() + " ";
+
+                    // TODO Handle when the name is very long
+
+                    String versionWithDots = StringUtils.rightPad(left, INFO_PAD_SIZE - right.length(), ".");
+
+                    getLog().info(versionWithDots + right);
+                    yearsOutdated[0] += libYearsOutdated;
+                    libWeeksOutDated.getAndAdd(libWeeksOutdated);
+                });
+
+        getLog().info("");
+
+        return yearsOutdated[0];
+    }
+
+    /**
+     * Make an API call to {@link #SEARCH_URI} to fetch the release date of the specified artifact.
+     * Uses the cache in {@link #dependencyVersionReleaseDates} if possible.
+     *
+     * @param groupId The required artifact's groupId
+     * @param artifactId The required artifact's artifactId
+     * @param version The required artifact's version
+     * @return The creation date of the artifact
+     */
+    private Optional<LocalDate> getReleaseDate(String groupId, String artifactId, String version) {
+        String ga = groupId + ":" + artifactId;
+        Map<String, LocalDate> versionReleaseDates = dependencyVersionReleaseDates.getOrDefault(ga, Maps.newHashMap());
+        if (versionReleaseDates.containsKey(version)) {
+            return Optional.of(versionReleaseDates.get(version));
+        }
+
+        try {
+            Optional<String> response = fetchReleaseDate(groupId, artifactId, version);
+
+            if (response.isEmpty()) {
+                return Optional.empty();
+            }
+
+            JSONObject json = new JSONObject(response.get());
+            JSONObject queryResponse = json.getJSONObject("response");
+            if (queryResponse.getLong("numFound") != 0) {
+                long epochTime =
+                        queryResponse.getJSONArray("docs").getJSONObject(0).getLong("timestamp");
+
+                getLog().debug("Found release time "
+                        + epochTime
+                        + " for "
+                        + groupId
+                        + ":"
+                        + artifactId
+                        + ":"
+                        + version);
+                LocalDate releaseDate = Instant.ofEpochMilli(epochTime)
+                        .atZone(ZoneId.systemDefault())
+                        .toLocalDate();
+
+                versionReleaseDates.put(version, releaseDate);
+                dependencyVersionReleaseDates.put(ga, versionReleaseDates);
+                return Optional.of(releaseDate);
+            } else {
+                getLog().debug("Could not find artifact for " + groupId + ":" + artifactId + " " + version);
+                return Optional.empty();
+            }
+        } catch (Exception e) {
+            getLog().error(String.format("Failed to fetch release date for %s %s: %s", ga, version, e.getMessage()));
+            return Optional.empty();
+        }
+    }
+
+    /** Make the API call to fetch the release date */
+    private Optional<String> fetchReleaseDate(String groupId, String artifactId, String version) throws IOException {
+        URI artifactUri = URI.create(String.format(
+                "%s/solrsearch/select?q=g:%s+AND+a:%s+AND+v:%s&wt=json", SEARCH_URI, groupId, artifactId, version));
+
+        getLog().debug("Fetching " + artifactUri);
+
+        RequestConfig config = RequestConfig.custom()
+                .setConnectTimeout(MAVEN_API_HTTP_TIMEOUT_SECONDS * 1000)
+                .setConnectionRequestTimeout(MAVEN_API_HTTP_TIMEOUT_SECONDS * 1000)
+                .setSocketTimeout(MAVEN_API_HTTP_TIMEOUT_SECONDS * 1000)
+                .build();
+
+        try (CloseableHttpClient httpClient = HttpClientBuilder.create()
+                .setDefaultRequestConfig(config)
+                .addInterceptorLast((HttpResponseInterceptor) (response, context) -> {
+                    // By default Apache HTTP client doesn't retry on 5xx
+                    // errors
+                    if (response.getStatusLine().getStatusCode() >= 500) {
+                        throw new IOException(response.getStatusLine().getReasonPhrase());
+                    }
+                })
+                .setRetryHandler(new RetryAllExceptionsLoggingHandler(getLog(), MAVEN_API_HTTP_RETRY_COUNT, true))
+                .build()) {
+            final HttpGet httpGet = new HttpGet(artifactUri);
+
+            try (CloseableHttpResponse response = httpClient.execute(httpGet)) {
+                if (response.getStatusLine().getStatusCode() != 200) {
+                    getLog().error(String.format(
+                            "Failed to fetch release date for %s:%s %s (%s)",
+                            groupId,
+                            artifactId,
+                            version,
+                            response.getStatusLine().getReasonPhrase()));
+                    return Optional.empty();
+                }
+
+                String responseBody = EntityUtils.toString(response.getEntity(), StandardCharsets.UTF_8);
+                return Optional.of(responseBody);
+            } catch (ConnectTimeoutException | SocketTimeoutException e) {
+                getLog().error(String.format(
+                        "Failed to fetch release date for %s:%s %s (%s)",
+                        groupId, artifactId, version, "request timed out"));
+                return Optional.empty();
+            }
+        }
+    }
+
+    /**
+     * Calculate if this is the last project in a multi-project pom. This is used to show a total
+     * "libyears outdated" figure for this project and all child projects.
+     *
+     * @return Whether this is the last project to be analysed by the plugin
+     */
+    private boolean isLastProjectInReactor() {
+        return readyProjectsCounter.incrementAndGet() != session.getProjects().size();
+    }
+
+    private static class RetryAllExceptionsLoggingHandler extends DefaultHttpRequestRetryHandler {
+        Log logger;
+
+        /**
+         * The superclass has a third constructor parameter listing Exception classes to not retry
+         * on, this class just passes an empty list. It also logs each retry.
+         *
+         * @param logger
+         * @param retryCount
+         * @param requestSentRetryEnabled
+         */
+        public RetryAllExceptionsLoggingHandler(Log logger, int retryCount, boolean requestSentRetryEnabled) {
+            super(retryCount, requestSentRetryEnabled, new ArrayList<>());
+            this.logger = logger;
+        }
+
+        @Override
+        public boolean retryRequest(IOException exception, int executionCount, HttpContext context) {
+            logger.debug("Retrying count " + executionCount);
+            return super.retryRequest(exception, executionCount, context);
+        }
+    }
 }

--- a/src/test/java/com/mfoot/mojo/libyear/InMemoryTestLogger.java
+++ b/src/test/java/com/mfoot/mojo/libyear/InMemoryTestLogger.java
@@ -16,94 +16,75 @@
 
 package com.mfoot.mojo.libyear;
 
-import org.apache.maven.plugin.logging.Log;
-
 import java.util.ArrayList;
 import java.util.List;
+import org.apache.maven.plugin.logging.Log;
 
 class InMemoryTestLogger implements Log {
 
-	public final List<String> infoLogs = new ArrayList<>();
-	public final List<String> errorLogs = new ArrayList<>();
-	public final List<String> debugLogs = new ArrayList<>();
+    public final List<String> infoLogs = new ArrayList<>();
+    public final List<String> errorLogs = new ArrayList<>();
+    public final List<String> debugLogs = new ArrayList<>();
 
-	@Override
-	public boolean isDebugEnabled() {
-		return true;
-	}
+    @Override
+    public boolean isDebugEnabled() {
+        return true;
+    }
 
-	@Override
-	public void debug(CharSequence charSequence) {
-		debugLogs.add(charSequence.toString());
-	}
+    @Override
+    public void debug(CharSequence charSequence) {
+        debugLogs.add(charSequence.toString());
+    }
 
-	@Override
-	public void debug(CharSequence charSequence, Throwable throwable) {
+    @Override
+    public void debug(CharSequence charSequence, Throwable throwable) {}
 
-	}
+    @Override
+    public void debug(Throwable throwable) {}
 
-	@Override
-	public void debug(Throwable throwable) {
+    @Override
+    public boolean isInfoEnabled() {
+        return false;
+    }
 
-	}
+    @Override
+    public void info(CharSequence charSequence) {
+        infoLogs.add(charSequence.toString());
+    }
 
-	@Override
-	public boolean isInfoEnabled() {
-		return false;
-	}
+    @Override
+    public void info(CharSequence charSequence, Throwable throwable) {}
 
-	@Override
-	public void info(CharSequence charSequence) {
-		infoLogs.add(charSequence.toString());
-	}
+    @Override
+    public void info(Throwable throwable) {}
 
-	@Override
-	public void info(CharSequence charSequence, Throwable throwable) {
+    @Override
+    public boolean isWarnEnabled() {
+        return false;
+    }
 
-	}
+    @Override
+    public void warn(CharSequence charSequence) {}
 
-	@Override
-	public void info(Throwable throwable) {
+    @Override
+    public void warn(CharSequence charSequence, Throwable throwable) {}
 
-	}
+    @Override
+    public void warn(Throwable throwable) {}
 
-	@Override
-	public boolean isWarnEnabled() {
-		return false;
-	}
+    @Override
+    public boolean isErrorEnabled() {
+        return false;
+    }
 
-	@Override
-	public void warn(CharSequence charSequence) {
+    @Override
+    public void error(CharSequence charSequence) {
+        errorLogs.add(charSequence.toString());
+    }
 
-	}
+    @Override
+    public void error(CharSequence charSequence, Throwable throwable) {}
 
-	@Override
-	public void warn(CharSequence charSequence, Throwable throwable) {
-
-	}
-
-	@Override
-	public void warn(Throwable throwable) {
-
-	}
-
-	@Override
-	public boolean isErrorEnabled() {
-		return false;
-	}
-
-	@Override
-	public void error(CharSequence charSequence) {
-		errorLogs.add(charSequence.toString());
-	}
-
-	@Override
-	public void error(CharSequence charSequence, Throwable throwable) {
-
-	}
-
-	@Override
-	public void error(Throwable throwable) {
-
-	}
+    @Override
+    public void error(Throwable throwable) {}
 }

--- a/src/test/java/com/mfoot/mojo/libyear/LibYearMojoTest.java
+++ b/src/test/java/com/mfoot/mojo/libyear/LibYearMojoTest.java
@@ -16,27 +16,6 @@
 
 package com.mfoot.mojo.libyear;
 
-import com.github.tomakehurst.wiremock.junit5.WireMockTest;
-import org.apache.maven.model.Dependency;
-import org.apache.maven.model.Plugin;
-import org.apache.maven.plugin.MojoExecutionException;
-import org.codehaus.mojo.versions.filtering.WildcardMatcher;
-import org.codehaus.mojo.versions.utils.DependencyBuilder;
-import org.json.JSONArray;
-import org.json.JSONObject;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.junit.jupiter.MockitoExtension;
-import org.mockito.junit.jupiter.MockitoSettings;
-import org.mockito.quality.Strictness;
-
-import java.time.LocalDateTime;
-import java.time.ZoneOffset;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Set;
-
 import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
@@ -57,6 +36,26 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.github.tomakehurst.wiremock.junit5.WireMockTest;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Set;
+import org.apache.maven.model.Dependency;
+import org.apache.maven.model.Plugin;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.codehaus.mojo.versions.filtering.WildcardMatcher;
+import org.codehaus.mojo.versions.utils.DependencyBuilder;
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
 /**
  * Note: This class uses <code>Strictness.LENIENT</code> because some mocks are set up by the
  * versions-maven-plugin and these use an older version of Mockito.
@@ -66,853 +65,1051 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 @WireMockTest(httpPort = 8080)
 public class LibYearMojoTest {
 
-	// TODO: Tests with version numbers being referenced by variables
-	// TODO: Test with version ranges
-	// TODO: Cleanup
-	// TODO: Run code formatter via plugin and enforce format
-	// TODO: This file is using spaces, not tabs
-
-	/**
-	 * Test factory method. Generates a Plugin object representing the specified parameters.
-	 *
-	 * @param artifactId The Maven artifact ID
-	 * @param groupId The Maven group ID
-	 * @param version The Maven version
-	 * @return The Plugin object
-	 */
-	private static Plugin pluginOf(String artifactId, String groupId, String version) {
-		Plugin plugin = new Plugin();
-		plugin.setGroupId(groupId);
-		plugin.setArtifactId(artifactId);
-		plugin.setVersion(version);
-		return plugin;
-	}
-
-	@AfterEach
-	public void reset() {
-		// TODO: Make these private and add a reset method in the mojo
-		LibYearMojo.libWeeksOutDated.set(0);
-		LibYearMojo.dependencyVersionReleaseDates.clear();
-		LibYearMojo.readyProjectsCounter.set(0);
-	}
-
-	/**
-	 * This is a basic test to ensure that a project with a single dependency correctly shows available updates.
-	 */
-	@Test
-	public void dependencyUpdateAvailable() throws Exception {
-		LibYearMojo mojo = new LibYearMojo(mockRepositorySystem(), mockAetherRepositorySystem(new HashMap<>() {{
-			put("default-dependency", new String[]{"1.0.0", "1.1.0", "2.0.0"});
-		}})
-
-		) {{
-			setProject(new MavenProjectBuilder().withDependencies(singletonList(DependencyBuilder.newBuilder().withGroupId("default-group").withArtifactId("default-dependency").withVersion("1.0.0").build())).build());
-			allowProcessingAllDependencies(this);
-			setPluginContext(new HashMap<>());
-
-			setSession(mockMavenSession());
-			setSearchUri("http://localhost:8080");
-
-			setLog(new InMemoryTestLogger());
-		}};
-
-		LocalDateTime now = LocalDateTime.now();
-
-		// Mark version 2.0.0 as a year newer
-		// Don't stub 1.1.0, there's no need to check its version
-		stubResponseFor("default-group", "default-dependency", "1.0.0", now.minusYears(1));
-		stubResponseFor("default-group", "default-dependency", "2.0.0", now);
-
-		mojo.execute();
-
-		assertTrue(((InMemoryTestLogger) mojo.getLog()).infoLogs.stream().anyMatch((l) ->
-				l.contains("default-group:default-dependency") && l.contains("1.00 libyears")));
-		assertTrue(((InMemoryTestLogger) mojo.getLog()).errorLogs.isEmpty());
-	}
-
-	/**
-	 * This test checks that the output for dependencies with long names is formatted correctly.
-	 */
-	@Test
-	public void dependencyUpdateWithLongNameAvailable() throws Exception {
-		LibYearMojo mojo = new LibYearMojo(mockRepositorySystem(), mockAetherRepositorySystem(new HashMap<>() {{
-			put("default-dependency-with-very-very-long-name", new String[]{"1.0.0", "1.1.0", "2.0.0"});
-		}})
-
-		) {{
-			setProject(new MavenProjectBuilder().withDependencies(singletonList(DependencyBuilder
-					.newBuilder().withGroupId("default-group")
-					.withArtifactId("default-dependency-with-very-very-long-name").withVersion("1.0.0").build())).build());
-			allowProcessingAllDependencies(this);
-			setPluginContext(new HashMap<>());
-
-			setSession(mockMavenSession());
-			setSearchUri("http://localhost:8080");
-
-			setLog(new InMemoryTestLogger());
-		}};
-
-		LocalDateTime now = LocalDateTime.now();
-
-		// Mark version 2.0.0 as a year newer
-		stubResponseFor("default-group", "default-dependency-with-very-very-long-name", "1.0.0", now.minusYears(1));
-		stubResponseFor("default-group", "default-dependency-with-very-very-long-name", "2.0.0", now);
-
-		mojo.execute();
-
-		// TODO: Implement wrapping for libyear output for dependencies with long names then update this test
-		assertTrue(((InMemoryTestLogger) mojo.getLog()).infoLogs.stream().anyMatch((l) ->
-				l.contains("default-group:default-dependency-with-very-very-long-name") && l.contains("1.00 libyears")));
-		assertTrue(((InMemoryTestLogger) mojo.getLog()).errorLogs.isEmpty());
-	}
-
-	@Test
-	public void dependencyUpdateAvailableButDependencyIsExcluded() throws Exception {
-		LibYearMojo mojo = new LibYearMojo(mockRepositorySystem(), mockAetherRepositorySystem(new HashMap<>() {{
-			put("default-dependency", new String[]{"1.0.0", "2.0.0"});
-		}})
-
-		) {{
-			setProject(new MavenProjectBuilder().withDependencies(singletonList(DependencyBuilder.newBuilder().withGroupId("default-group").withArtifactId("default-dependency").withVersion("1.0.0").build())).build());
-			allowProcessingAllDependencies(this);
-
-			setVariableValueToObject(this, "dependencyExcludes", List.of("default-group:default-dependency"));
-
-			setPluginContext(new HashMap<>());
-
-			setSession(mockMavenSession());
-			setSearchUri("http://localhost:8080");
-
-			setLog(new InMemoryTestLogger());
-		}};
-
-		// No need to stub output as no API calls should be made
-
-		mojo.execute();
-
-		assertFalse(((InMemoryTestLogger) mojo.getLog()).infoLogs.stream().anyMatch((l) ->
-				l.contains("default-group:default-dependency")));
-		assertTrue(((InMemoryTestLogger) mojo.getLog()).errorLogs.isEmpty());
-	}
-
-	@Test
-	public void dependencyUpdateAvailableButVersionIsIgnored() throws Exception {
-		LibYearMojo mojo = new LibYearMojo(mockRepositorySystem(), mockAetherRepositorySystem(new HashMap<>() {{
-			put("default-dependency", new String[]{"1.0.0", "2.0.0"});
-		}})
-
-		) {{
-			setProject(new MavenProjectBuilder().withDependencies(singletonList(DependencyBuilder.newBuilder().withGroupId("default-group").withArtifactId("default-dependency").withVersion("1.0.0").build())).build());
-			allowProcessingAllDependencies(this);
-
-			setVariableValueToObject(this, "ignoredVersions", Set.of("2.0.0"));
-
-			setPluginContext(new HashMap<>());
-
-			setSession(mockMavenSession());
-			setSearchUri("http://localhost:8080");
-
-			setLog(new InMemoryTestLogger());
-		}};
-
-		// No need to stub output as no API calls should be made
-
-		mojo.execute();
-
-		assertFalse(((InMemoryTestLogger) mojo.getLog()).infoLogs.stream().anyMatch((l) ->
-				l.contains("default-group:default-dependency")));
-		assertTrue(((InMemoryTestLogger) mojo.getLog()).errorLogs.isEmpty());
-	}
-
-	@Test
-	public void dependencyUpdateAvailableButProcessingDependenciesIsDisabled() throws Exception {
-		LibYearMojo mojo = new LibYearMojo(mockRepositorySystem(), mockAetherRepositorySystem(new HashMap<>() {{
-			put("default-dependency", new String[]{"1.0.0", "1.1.0", "2.0.0"});
-		}})
-
-		) {{
-			setProject(new MavenProjectBuilder().withDependencies(singletonList(DependencyBuilder.newBuilder().withGroupId("default-group").withArtifactId("default-dependency").withVersion("1.0.0").build())).build());
-			allowProcessingAllDependencies(this);
-			setVariableValueToObject(this, "processDependencies", false);
-
-			setPluginContext(new HashMap<>());
-
-			setSession(mockMavenSession());
-			setSearchUri("http://localhost:8080");
-
-			setLog(new InMemoryTestLogger());
-		}};
-
-		LocalDateTime now = LocalDateTime.now();
-
-		// Mark version 2.0.0 as a year newer
-		// Don't stub 1.1.0, there's no need to check its version
-		stubResponseFor("default-group", "default-dependency", "1.0.0", now.minusYears(1));
-		stubResponseFor("default-group", "default-dependency", "2.0.0", now);
-
-		mojo.execute();
-
-		assertFalse(((InMemoryTestLogger) mojo.getLog()).infoLogs.stream().anyMatch((l) ->
-				l.contains("default-group:default-dependency")));
-		assertTrue(((InMemoryTestLogger) mojo.getLog()).errorLogs.isEmpty());
-	}
-
-	/**
-	 * The plugin should cache the result of API calls to find the release date of every dependency that it makes.
-	 * This test ensures that despite running the plugin twice, we only make one API call for each dependency version.
-	 */
-	@Test
-	public void cacheIsUsedForDependencyVersions() throws Exception {
-		// Run one of the tests twice, which should only trigger one fetch per dependency version
-		dependencyUpdateAvailable();
-		dependencyUpdateAvailable();
-
-		// One call for v1.0.0
-		verify(1,
-				getRequestedFor(urlPathEqualTo("/solrsearch/select"))
-						.withQueryParam("q", equalTo("g:default-group AND a:default-dependency AND v:1.0.0")));
-
-		// One call for v2.0.0
-		verify(1, getRequestedFor(urlPathEqualTo("/solrsearch/select"))
-				.withQueryParam("q", equalTo("g:default-group AND a:default-dependency AND v:2.0.0")));
-	}
-
-	@Test
-	public void dependencyUpdateAvailableWhenVersionSpecifiedInDependencyManagement() throws Exception {
-		LibYearMojo mojo = new LibYearMojo(mockRepositorySystem(), mockAetherRepositorySystem(new HashMap<>() {{
-			put("default-dependency", new String[]{"1.0.0", "1.1.0", "2.0.0"});
-		}})
-
-		) {{
-			setProject(new MavenProjectBuilder()
-					.withDependencies(singletonList(DependencyBuilder.newBuilder()
-							.withGroupId("default-group")
-							.withArtifactId("default-dependency")
-							.withVersion("1.0.0") // This is overridden by dependencyManagement
-					.build()))
-					.withDependencyManagementDependencyList(
-							singletonList(DependencyBuilder.newBuilder()
-									.withGroupId("default-group")
-									.withArtifactId("default-dependency")
-									.withVersion("1.1.0").build()))
-					.build());
-			allowProcessingAllDependencies(this);
-			setPluginContext(new HashMap<>());
-
-			setSession(mockMavenSession());
-			setSearchUri("http://localhost:8080");
-
-			setLog(new InMemoryTestLogger());
-		}};
-
-		LocalDateTime now = LocalDateTime.now();
-
-		// Mark version 2.0.0 as a year newer than the version specified by dependencyManagement
-		stubResponseFor("default-group", "default-dependency", "1.0.0", now.minusYears(2));
-		stubResponseFor("default-group", "default-dependency", "1.1.0", now.minusYears(1));
-		stubResponseFor("default-group", "default-dependency", "2.0.0", now);
-
-		mojo.execute();
-
-		assertTrue(((InMemoryTestLogger) mojo.getLog()).infoLogs.stream().anyMatch((l) -> l.contains("default-group:default-dependency") && l.contains("1.00 libyears")));
-
-		assertTrue(((InMemoryTestLogger) mojo.getLog()).errorLogs.isEmpty());
-	}
-
-	/**
-	 * This test has a project with a dependency with version 1.0.0. Dependency management pins it at 1.1.0, and
-	 * 2.0.0 is available. We exclude the plugin from considering dependency management, meaning we should show the age
-	 * between 1.0.0 and 2.0.0.
-	 * @throws Exception
-	 */
-	@Test
-	public void dependencyUpdateAvailableWhenVersionSpecifiedInDependencyManagementButDependencyExcludedFromDependencyManagement() throws Exception {
-		LibYearMojo mojo = new LibYearMojo(mockRepositorySystem(), mockAetherRepositorySystem(new HashMap<>() {{
-			put("default-dependency", new String[]{"1.0.0", "1.1.0", "2.0.0"});
-		}})
-
-		) {{
-			setProject(new MavenProjectBuilder()
-					.withDependencies(singletonList(DependencyBuilder.newBuilder()
-							.withGroupId("default-group")
-							.withArtifactId("default-dependency")
-							.withVersion("1.0.0") // This is overridden by dependencyManagement
-							.build()))
-					.withDependencyManagementDependencyList(
-							singletonList(DependencyBuilder.newBuilder()
-									.withGroupId("default-group")
-									.withArtifactId("default-dependency")
-									.withVersion("1.1.0").build()))
-					.build());
-			allowProcessingAllDependencies(this);
-
-			setVariableValueToObject(this, "dependencyManagementExcludes", List.of("default-group:default-dependency"));
-
-			setPluginContext(new HashMap<>());
-
-			setSession(mockMavenSession());
-			setSearchUri("http://localhost:8080");
-
-			setLog(new InMemoryTestLogger());
-		}};
-
-		LocalDateTime now = LocalDateTime.now();
-
-		// Mark version 2.0.0 as a year newer than the version specified by dependencyManagement
-		stubResponseFor("default-group", "default-dependency", "1.0.0", now.minusYears(2));
-		stubResponseFor("default-group", "default-dependency", "1.1.0", now.minusYears(1));
-		stubResponseFor("default-group", "default-dependency", "2.0.0", now);
-
-		mojo.execute();
-
-		assertTrue(((InMemoryTestLogger) mojo.getLog()).infoLogs.stream().anyMatch((l) ->
-				l.contains("default-group:default-dependency") && l.contains("2.00 libyears")));
-
-		assertTrue(((InMemoryTestLogger) mojo.getLog()).errorLogs.isEmpty());
-	}
-
-	/**
-	 * This test has a project with a two-year-old dependency where the dependency version is overridden by the
-	 * dependencyManagement section to use a one-year-old version, but the plugin setting enableDependencyManagement is
-	 * set to false. We should ignore the one-year-old version and suggest that the dependency is two years out-of-date.
-	 */
-	@Test
-	public void dependencyUpdateAvailableWhenVersionSpecifiedInDependencyManagementWhereProcessDependencyManagementIsDisabled() throws Exception {
-		LibYearMojo mojo = new LibYearMojo(mockRepositorySystem(), mockAetherRepositorySystem(new HashMap<>() {{
-			put("default-dependency", new String[]{"1.0.0", "1.1.0", "2.0.0"});
-		}})
-
-		) {{
-			setProject(new MavenProjectBuilder()
-					.withDependencies(singletonList(DependencyBuilder.newBuilder()
-							.withGroupId("default-group")
-							.withArtifactId("default-dependency")
-							.withVersion("1.0.0") // This is overridden by dependencyManagement
-							.build()))
-					.withDependencyManagementDependencyList(
-							singletonList(DependencyBuilder.newBuilder()
-									.withGroupId("default-group")
-									.withArtifactId("default-dependency")
-									.withVersion("1.1.0").build()))
-					.build());
-			allowProcessingAllDependencies(this);
-			setVariableValueToObject(this, "processDependencyManagement", false);
-			setPluginContext(new HashMap<>());
-
-			setSession(mockMavenSession());
-			setSearchUri("http://localhost:8080");
-
-			setLog(new InMemoryTestLogger());
-		}};
-
-		LocalDateTime now = LocalDateTime.now();
-
-		// Mark version 2.0.0 as a year newer than the version specified by dependencyManagement
-		stubResponseFor("default-group", "default-dependency", "1.0.0", now.minusYears(2));
-		stubResponseFor("default-group", "default-dependency", "1.1.0", now.minusYears(1));
-		stubResponseFor("default-group", "default-dependency", "2.0.0", now);
-
-		mojo.execute();
-
-		assertTrue(((InMemoryTestLogger) mojo.getLog()).infoLogs.stream().anyMatch((l) -> l.contains("default-group:default-dependency") && l.contains("2.00 libyears")));
-
-		assertTrue(((InMemoryTestLogger) mojo.getLog()).errorLogs.isEmpty());
-	}
-
-	/**
-	 * This test has a dependency with version 1.0.0, which is overridden by
-	 * dependencyManagement to 1.1.0. Version 2.0.0 is available.
-	 * <p>
-	 * We ensure that the proposed change is the libyears between 1.1.0 and
-	 * 2.0.0.
-	 */
-	@Test
-	public void dependencyUpdateAvailableDependencyDefinedInDependencyManagement() throws Exception {
-		LibYearMojo mojo = new LibYearMojo(mockRepositorySystem(), mockAetherRepositorySystem(new HashMap<>() {{
-			put("default-dependency", new String[]{"1.0.0", "1.1.0", "2.0.0"});
-		}})
-
-		) {{
-			setProject(new MavenProjectBuilder().withDependencies(
-					singletonList(DependencyBuilder.newBuilder()
-							.withGroupId("default-group")
-							.withArtifactId("default-dependency")
-							.withVersion("1.0.0")
-							.build()))
-					.withDependencyManagementDependencyList(singletonList(DependencyBuilder.newBuilder()
-							.withGroupId("default-group")
-							.withArtifactId("default-dependency")
-							.withVersion("1.1.0")
-							.build()))
-					.build());
-			allowProcessingAllDependencies(this);
-			setPluginContext(new HashMap<>());
-
-			setSession(mockMavenSession());
-			setSearchUri("http://localhost:8080");
-
-			setLog(new InMemoryTestLogger());
-		}};
-
-		LocalDateTime now = LocalDateTime.now();
-
-		// Mark version 2.0.0 as a year newer. The current dependency version is 1.1.0, overridden from 1.0.0 by
-		// dependencyManagement
-
-		// TODO: This first stub probably shouldn't be needed as we shouldn't need to fetch the release year of this version
-		// but without it, the test fails.
-		stubResponseFor("default-group", "default-dependency", "1.0.0", now.minusYears(10));
-		stubResponseFor("default-group", "default-dependency", "1.1.0", now.minusYears(1));
-		stubResponseFor("default-group", "default-dependency", "2.0.0", now);
-
-		mojo.execute();
-
-		assertTrue(((InMemoryTestLogger) mojo.getLog()).infoLogs.stream().anyMatch(
-				(l) -> l.contains("default-group:default-dependency") && l.contains("1.00 libyears")));
-		assertTrue(((InMemoryTestLogger) mojo.getLog()).errorLogs.isEmpty());
-	}
-
-	@Test
-	public void pluginVersionUpdateAvailable() throws Exception {
-		Plugin plugin = pluginOf("default-plugin", "default-group", "1.0.0");
-		plugin.setDependencies(singletonList(dependencyFor("default-group", "default-dependency", "1.0.0")));
-
-		LibYearMojo mojo = new LibYearMojo(mockRepositorySystem(), mockAetherRepositorySystem(new HashMap<>() {{
-			put("default-dependency", new String[]{"1.0.0", "1.1.0", "2.0.0"});
-		}})
-
-		) {{
-			setProject(new MavenProjectBuilder().withPlugins(singletonList(plugin)).build());
-
-			allowProcessingAllDependencies(this);
-			setPluginContext(new HashMap<>());
-
-			setSession(mockMavenSession());
-			setSearchUri("http://localhost:8080");
-
-			setLog(new InMemoryTestLogger());
-		}};
-
-		LocalDateTime now = LocalDateTime.now();
-
-		// Mark version 2.0.0 as a year newer
-		stubResponseFor("default-group", "default-dependency", "1.0.0", now.minusYears(1));
-		stubResponseFor("default-group", "default-dependency", "2.0.0", now);
-
-		mojo.execute();
-
-		assertTrue(((InMemoryTestLogger) mojo.getLog()).infoLogs.stream().anyMatch((l) ->
-				l.contains("default-group:default-dependency") && l.contains("1.00 libyears")));
-		assertTrue(((InMemoryTestLogger) mojo.getLog()).errorLogs.isEmpty());
-	}
-
-	/**
-	 * This test has a plugin version 1.0.0 which has a dependency on another
-	 * artifact version 1.0.1. That version is overridden in dependency management
-	 * to 1.1.0. Version 2.0.0 is available.
-	 * <p>
-	 * This test ensures we suggest the libyears between 1.1.0 and 2.0.0.
-	 */
-	@Test
-	public void pluginVersionUpdateAvailableDependencyDefinedInDependencyManagement() throws Exception {
-		Plugin plugin = pluginOf("default-plugin", "default-group", "1.0.0");
-		plugin.setDependencies(singletonList(dependencyFor("default-group", "default-dependency", "1.0.1")));
-
-		LibYearMojo mojo = new LibYearMojo(mockRepositorySystem(), mockAetherRepositorySystem(new HashMap<>() {{
-			put("default-dependency", new String[]{"1.0.0", "1.1.0", "2.0.0"});
-		}})
-
-		) {{
-			setProject(new MavenProjectBuilder().withPlugins(singletonList(plugin)).withDependencyManagementDependencyList(singletonList(DependencyBuilder.newBuilder().withGroupId("default-group").withArtifactId("default-dependency").withVersion("1.1.0").build())).build());
-
-			allowProcessingAllDependencies(this);
-			setPluginContext(new HashMap<>());
-
-			setSession(mockMavenSession());
-			setSearchUri("http://localhost:8080");
-
-			setLog(new InMemoryTestLogger());
-		}};
-
-		LocalDateTime now = LocalDateTime.now();
-
-		// Mark version 2.0.0 as a year newer
-		stubResponseFor("default-group", "default-dependency", "1.0.1", now.minusYears(2));
-		stubResponseFor("default-group", "default-dependency", "1.1.0", now.minusYears(1));
-		stubResponseFor("default-group", "default-dependency", "2.0.0", now);
-
-		mojo.execute();
-
-		assertTrue(((InMemoryTestLogger) mojo.getLog()).infoLogs.stream().anyMatch((l) ->
-				l.contains("default-group:default-dependency") && l.contains("1.00 libyears")));
-		assertTrue(((InMemoryTestLogger) mojo.getLog()).errorLogs.isEmpty());
-	}
-
-	/**
-	 * This test has a plugin version 1.0.0. That version is overridden in plugin management to 1.1.0.
-	 * Version 2.0.0 is available.
-	 * <p>
-	 * This test ensures we suggest the libyears between 1.1.0 and 2.0.0.
-	 */
-	@Test
-	public void pluginVersionUpdateAvailableDependencyDefinedInPluginManagement() throws Exception {
-		Plugin plugin = pluginOf("default-plugin", "default-group", "1.0.0");
-		plugin.setDependencies(singletonList(dependencyFor("default-group", "default-dependency", "1.0.1")));
-
-		Plugin managedPlugin = pluginOf("default-plugin", "default-group", "1.0.0");
-		plugin.setDependencies(singletonList(dependencyFor("default-group", "default-dependency", "1.1.0")));
-
-		LibYearMojo mojo = new LibYearMojo(mockRepositorySystem(), mockAetherRepositorySystem(new HashMap<>() {{
-			put("default-dependency", new String[]{"1.0.0", "1.1.0", "2.0.0"});
-		}})
-
-		) {{
-			setProject(new MavenProjectBuilder()
-					.withPlugins(singletonList(plugin))
-					.withPluginManagementPluginList(singletonList(managedPlugin)).build());
-
-			allowProcessingAllDependencies(this);
-
-			setPluginContext(new HashMap<>());
-
-			setSession(mockMavenSession());
-			setSearchUri("http://localhost:8080");
-
-			setLog(new InMemoryTestLogger());
-		}};
-
-		LocalDateTime now = LocalDateTime.now();
-
-		// Mark version 2.0.0 as a year newer
-		stubResponseFor("default-group", "default-dependency", "1.1.0", now.minusYears(1));
-		stubResponseFor("default-group", "default-dependency", "2.0.0", now);
-
-		mojo.execute();
-
-		assertTrue(((InMemoryTestLogger) mojo.getLog()).infoLogs.stream().anyMatch((l) -> l.contains("default-group:default-dependency") && l.contains("1.00 libyears")));
-		assertTrue(((InMemoryTestLogger) mojo.getLog()).errorLogs.isEmpty());
-	}
-
-	private Dependency dependencyFor(String groupID, String artifactId, String version) {
-		Dependency dep = new Dependency();
-		dep.setGroupId(groupID);
-		dep.setArtifactId(artifactId);
-		dep.setVersion(version);
-		return dep;
-	}
-
-	/**
-	 * Stub the Maven search API response that looks for release information for a particular version of a particular
-	 * artifact
-	 */
-	private void stubResponseFor(String groupId, String artifactId, String version, LocalDateTime time) {
-		stubFor(get(urlPathEqualTo("/solrsearch/select")).withQueryParam("q", equalTo(String.format("g:%s AND a:%s AND v:%s", groupId, artifactId, version))).withQueryParam("wt", equalTo("json")).willReturn(ok(getJSONResponseForVersion(groupId, artifactId, version, time))));
-	}
-
-	/**
-	 * Simulate the JSON response from the Maven Central repository search API. Docs available at
-	 * <a href="https://central.sonatype.org/search/rest-api-guide/">here</a>.
-	 */
-	private String getJSONResponseForVersion(String groupId, String artifactId, String version, LocalDateTime releaseDate) {
-		JSONObject root = new JSONObject();
-		JSONObject response = new JSONObject();
-		JSONArray versions = new JSONArray();
-		JSONObject newVersion = new JSONObject();
-
-		newVersion.put("id", String.format("%s:%s:%s", groupId, artifactId, version));
-		newVersion.put("g", groupId);
-		newVersion.put("a", artifactId);
-		newVersion.put("v", version);
-		newVersion.put("p", "jar");
-		newVersion.put("timestamp", releaseDate.toEpochSecond(ZoneOffset.UTC) * 1000); // API response is in millis
-
-		versions.put(newVersion);
-		response.put("docs", versions);
-		response.put("numFound", 1);
-		root.put("response", response);
-
-		return root.toString();
-	}
-
-	@Test
-	public void apiCallToMavenFails() throws Exception {
-		LibYearMojo mojo = new LibYearMojo(mockRepositorySystem(), mockAetherRepositorySystem(new HashMap<>() {{
-			put("default-dependency", new String[]{"1.0.0", "2.0.0"});
-		}})) {{
-			setProject(new MavenProjectBuilder().withDependencies(singletonList(DependencyBuilder.newBuilder()
-					.withGroupId("default-group")
-					.withArtifactId("default-dependency")
-					.withVersion("1.0.0").build()))
-				.build());
-			allowProcessingAllDependencies(this);
-			setPluginContext(new HashMap<>());
-
-			setSession(mockMavenSession());
-			setSearchUri("http://localhost:8080");
-
-			setLog(new InMemoryTestLogger());
-		}};
-
-		stubFor(get(urlPathEqualTo("/solrsearch/select")).willReturn(serverError()));
-
-		mojo.execute();
-
-		assertTrue(((InMemoryTestLogger) mojo.getLog()).errorLogs.stream().anyMatch((l) ->
-				l.contains("Failed to fetch release date for default-group:default-dependency 1.0.0")));
-		assertTrue(((InMemoryTestLogger) mojo.getLog()).errorLogs.stream().anyMatch((l) ->
-				l.contains("Failed to fetch release date for default-group:default-dependency 2.0.0")));
-	}
-
-	@Test
-	public void apiCallToMavenTimesOut() throws Exception {
-		LibYearMojo mojo = new LibYearMojo(mockRepositorySystem(), mockAetherRepositorySystem(new HashMap<>() {{
-			put("default-dependency", new String[]{"1.0.0", "2.0.0"});
-		}})) {{
-			setProject(new MavenProjectBuilder().withDependencies(singletonList(DependencyBuilder.newBuilder()
-					.withGroupId("default-group")
-					.withArtifactId("default-dependency")
-					.withVersion("1.0.0").build())).build());
-			allowProcessingAllDependencies(this);
-			setPluginContext(new HashMap<>());
-
-			setSession(mockMavenSession());
-			setSearchUri("http://localhost:8080");
-			setHttpTimeout(1);
-			setFetchRetryCount(0);
-
-			setLog(new InMemoryTestLogger());
-		}};
-
-		stubFor(get(urlPathEqualTo("/solrsearch/select")).willReturn(ok().withFixedDelay(10_000 /* ms */)));
-
-		mojo.execute();
-
-		assertTrue(((InMemoryTestLogger) mojo.getLog()).errorLogs.stream().anyMatch((l) ->
-				l.contains("Failed to fetch release date for default-group:default-dependency 1.0.0 (request timed out)")));
-		assertTrue(((InMemoryTestLogger) mojo.getLog()).errorLogs.stream().anyMatch((l) ->
-				l.contains("Failed to fetch release date for default-group:default-dependency 2.0.0 (request timed out)")));
-		assertEquals(2, ((InMemoryTestLogger) mojo.getLog()).errorLogs.size());
-	}
-
-	@Test
-	public void apiCallToMavenRetriesOnFailure() throws Exception {
-		LibYearMojo mojo = new LibYearMojo(mockRepositorySystem(), mockAetherRepositorySystem(new HashMap<>() {{
-			put("default-dependency", new String[]{"1.0.0", "2.0.0"});
-		}})) {{
-			setProject(new MavenProjectBuilder().withDependencies(singletonList(DependencyBuilder.newBuilder()
-							.withGroupId("default-group")
-							.withArtifactId("default-dependency")
-							.withVersion("1.0.0").build()))
-					.build());
-			allowProcessingAllDependencies(this);
-			setPluginContext(new HashMap<>());
-
-			setSession(mockMavenSession());
-			setSearchUri("http://localhost:8080");
-
-			setFetchRetryCount(2);
-
-			setLog(new InMemoryTestLogger());
-		}};
-
-		LocalDateTime now = LocalDateTime.now();
-
-		// The first dependency should fail twice and return OK on the second retry
-		stubFor(get(urlPathEqualTo("/solrsearch/select"))
-				.withQueryParam("q",
-						equalTo(String.format("g:%s AND a:%s AND v:%s", "default-group", "default-dependency", "1.0.0")))
-				.inScenario("Failure chain")
-				.whenScenarioStateIs("Started")
-				.willReturn(serverError())
-				.willSetStateTo("First failure"));
-
-		stubFor(get(urlPathEqualTo("/solrsearch/select"))
-				.inScenario("Failure chain")
-				.whenScenarioStateIs("First failure")
-				.willReturn(serverError())
-				.willSetStateTo("Second failure"));
-
-		stubFor(get(urlPathEqualTo("/solrsearch/select"))
-				.inScenario("Failure chain")
-				.whenScenarioStateIs("Second failure")
-				.willReturn(ok(
-						getJSONResponseForVersion("default-group", "default-dependency", "1.0.0",
-								now.minusYears(1)))));
-
-		// The second request will succeed first time
-		stubResponseFor("default-group", "default-dependency", "2.0.0", now);
-
-		mojo.execute();
-
-		assertTrue(((InMemoryTestLogger) mojo.getLog()).infoLogs.stream().anyMatch(
-				(l) -> l.contains("default-group:default-dependency") && l.contains("1.00 libyears")));
-	}
-
-	@Test
-	public void dependencyUpdateAvailableButFetchingReleaseDateOfNewerVersionFails() throws Exception {
-		LibYearMojo mojo = new LibYearMojo(mockRepositorySystem(), mockAetherRepositorySystem(new HashMap<>() {{
-			put("default-dependency", new String[]{"1.0.0", "1.1.0", "2.0.0"});
-		}})
-
-		) {{
-			setProject(new MavenProjectBuilder().withDependencies(singletonList(DependencyBuilder.newBuilder()
-					.withGroupId("default-group")
-					.withArtifactId("default-dependency")
-					.withVersion("1.0.0").build())).build());
-
-			allowProcessingAllDependencies(this);
-
-			setPluginContext(new HashMap<>());
-
-			setSession(mockMavenSession());
-			setSearchUri("http://localhost:8080");
-
-			setLog(new InMemoryTestLogger());
-		}};
-
-		LocalDateTime now = LocalDateTime.now();
-
-		stubResponseFor("default-group", "default-dependency", "1.0.0", now.minusYears(1));
-		stubFor(get(urlPathEqualTo("/solrsearch/select"))
-				.withQueryParam("q", equalTo(String.format("g:%s AND a:%s AND v:%s", "default-group", "default-dependency", "2.0.0"))
-				).withQueryParam("wt", equalTo("json")).willReturn(serverError()));
-
-		mojo.execute();
-
-		assertFalse(((InMemoryTestLogger) mojo.getLog()).infoLogs.stream().anyMatch((l) -> l.contains("default-group:default-dependency")));
-		assertTrue(((InMemoryTestLogger) mojo.getLog()).errorLogs.contains("Failed to fetch release date for default-group:default-dependency 2.0.0: Server Error"));
-	}
-
-	@Test
-	public void dependencyUpdateAvailableButAPISearchDoesNotContainLatestVersion() throws Exception {
-		LibYearMojo mojo = new LibYearMojo(mockRepositorySystem(), mockAetherRepositorySystem(new HashMap<>() {{
-			put("default-dependency", new String[]{"1.0.0", "1.1.0", "2.0.0"});
-		}})
-
-		) {{
-			setProject(new MavenProjectBuilder().withDependencies(singletonList(DependencyBuilder.newBuilder()
-					.withGroupId("default-group")
-					.withArtifactId("default-dependency")
-					.withVersion("1.0.0").build())).build());
-			allowProcessingAllDependencies(this);
-			setPluginContext(new HashMap<>());
-
-			setSession(mockMavenSession());
-			setSearchUri("http://localhost:8080");
-
-			setLog(new InMemoryTestLogger());
-		}};
-
-		LocalDateTime now = LocalDateTime.now();
-
-		stubResponseFor("default-group", "default-dependency", "1.0.0", now.minusYears(1));
-		stubFor(get(urlPathEqualTo("/solrsearch/select")).withQueryParam("q", equalTo(String.format("g:%s AND a:%s AND v:%s", "default-group", "default-dependency", "2.0.0"))).withQueryParam("wt", equalTo("json")).willReturn(ok("{\"response\":{\"docs\":[],\"numFound\":0}}")));
-
-		mojo.execute();
-
-		assertFalse(((InMemoryTestLogger) mojo.getLog()).infoLogs.stream().anyMatch((l) -> l.contains("default-group:default-dependency")));
-		assertTrue(((InMemoryTestLogger) mojo.getLog()).debugLogs.contains("Could not find artifact for default-group:default-dependency 2.0.0"));
-	}
-
-	@Test
-	public void multipleDependenciesWithUpdatesAreSortedAlphabetically() throws Exception {
-		LibYearMojo mojo = new LibYearMojo(mockRepositorySystem(), mockAetherRepositorySystem(new HashMap<>() {{
-			put("default-dependency", new String[]{"1.0.0", "2.0.0"});
-			put("second-dependency", new String[]{"5.0.0", "6.0.0"});
-		}})
-
-		) {{
-			setProject(new MavenProjectBuilder()
-					.withDependencies(
-						List.of(
-								DependencyBuilder.newBuilder()
-										.withGroupId("default-group")
-										.withArtifactId("second-dependency")
-										.withVersion("5.0.0")
-										.build(),
-								DependencyBuilder.newBuilder()
-									.withGroupId("default-group")
-									.withArtifactId("default-dependency")
-									.withVersion("1.0.0")
-									.build()
-							))
-					.build());
-			allowProcessingAllDependencies(this);
-			setPluginContext(new HashMap<>());
-
-			setSession(mockMavenSession());
-			setSearchUri("http://localhost:8080");
-
-			setLog(new InMemoryTestLogger());
-		}};
-
-		LocalDateTime now = LocalDateTime.now();
-
-		// Mark version 2.0.0 as a year newer
-		// Don't stub 1.1.0, there's no need to check its version
-		stubResponseFor("default-group", "default-dependency", "1.0.0", now.minusYears(1));
-		stubResponseFor("default-group", "default-dependency", "2.0.0", now);
-		stubResponseFor("default-group", "second-dependency", "5.0.0", now.minusYears(5));
-		stubResponseFor("default-group", "second-dependency", "6.0.0", now.minusYears(3));
-
-		mojo.execute();
-
-		List<String> infoLogs = ((InMemoryTestLogger) mojo.getLog()).infoLogs;
-		String firstLogInvolvingDefaultGroup = infoLogs.stream()
-				.filter(l -> l.contains("default-group"))
-				.findFirst()
-				.get();
-		int indexOfFirstLog = infoLogs.indexOf(firstLogInvolvingDefaultGroup);
-		assertTrue(infoLogs.get(indexOfFirstLog + 1).contains("second-dependency"));
-		assertTrue(((InMemoryTestLogger) mojo.getLog()).errorLogs.isEmpty());
-	}
-
-	@Test
-	public void projectExceedsMaxLibYearsAndShouldFailTheBuild() throws Exception {
-		LibYearMojo mojo = new LibYearMojo(mockRepositorySystem(), mockAetherRepositorySystem(new HashMap<>() {{
-			put("default-dependency", new String[]{"1.0.0", "2.0.0"});
-		}})
-
-		) {{
-			setProject(new MavenProjectBuilder().withDependencies(singletonList(DependencyBuilder.newBuilder().withGroupId("default-group").withArtifactId("default-dependency").withVersion("1.0.0").build())).build());
-			allowProcessingAllDependencies(this);
-
-			setVariableValueToObject(this, "maxLibYears", 0.1f);
-
-			setPluginContext(new HashMap<>());
-
-			setSession(mockMavenSession());
-			setSearchUri("http://localhost:8080");
-
-			setLog(new InMemoryTestLogger());
-		}};
-
-		LocalDateTime now = LocalDateTime.now();
-
-		stubResponseFor("default-group", "default-dependency", "1.0.0", now.minusYears(1));
-		stubResponseFor("default-group", "default-dependency", "2.0.0", now);
-
-		MojoExecutionException ex = assertThrows(MojoExecutionException.class, mojo::execute);
-		assertEquals("Dependencies exceed maximum specified age in libyears", ex.getMessage());
-
-		assertTrue(((InMemoryTestLogger) mojo.getLog()).errorLogs.stream().anyMatch(
-				l -> l.contains("This project exceeds the maximum dependency age of 0.1 libyears"))
-		);
-	}
-
-	private void allowProcessingAllDependencies(LibYearMojo mojo) throws IllegalAccessException {
-		setVariableValueToObject(mojo, "ignoredVersions", emptySet());
-		setVariableValueToObject(mojo, "processDependencies", true);
-		setVariableValueToObject(mojo, "processPluginDependencies", true);
-		setVariableValueToObject(mojo, "pluginDependencyIncludes", singletonList(WildcardMatcher.WILDCARD));
-		setVariableValueToObject(mojo, "pluginDependencyExcludes", emptyList());
-		setVariableValueToObject(mojo, "processPluginDependenciesInPluginManagement", true);
-		setVariableValueToObject(mojo, "pluginManagementDependencyIncludes", singletonList(WildcardMatcher.WILDCARD));
-		setVariableValueToObject(mojo, "pluginManagementDependencyExcludes", emptyList());
-		setVariableValueToObject(mojo, "processDependencyManagement", true);
-		setVariableValueToObject(mojo, "dependencyManagementIncludes", singletonList(WildcardMatcher.WILDCARD));
-		setVariableValueToObject(mojo, "dependencyManagementExcludes", emptyList());
-		setVariableValueToObject(mojo, "dependencyIncludes", singletonList(WildcardMatcher.WILDCARD));
-		setVariableValueToObject(mojo, "dependencyExcludes", emptyList());
-	}
+    // TODO: Tests with version numbers being referenced by variables
+    // TODO: Test with version ranges
+    // TODO: Cleanup
+    // TODO: Run code formatter via plugin and enforce format
+    // TODO: This file is using spaces, not tabs
+
+    /**
+     * Test factory method. Generates a Plugin object representing the specified parameters.
+     *
+     * @param artifactId The Maven artifact ID
+     * @param groupId The Maven group ID
+     * @param version The Maven version
+     * @return The Plugin object
+     */
+    private static Plugin pluginOf(String artifactId, String groupId, String version) {
+        Plugin plugin = new Plugin();
+        plugin.setGroupId(groupId);
+        plugin.setArtifactId(artifactId);
+        plugin.setVersion(version);
+        return plugin;
+    }
+
+    @AfterEach
+    public void reset() {
+        // TODO: Make these private and add a reset method in the mojo
+        LibYearMojo.libWeeksOutDated.set(0);
+        LibYearMojo.dependencyVersionReleaseDates.clear();
+        LibYearMojo.readyProjectsCounter.set(0);
+    }
+
+    /**
+     * This is a basic test to ensure that a project with a single dependency correctly shows
+     * available updates.
+     */
+    @Test
+    public void dependencyUpdateAvailable() throws Exception {
+        LibYearMojo mojo =
+                new LibYearMojo(mockRepositorySystem(), mockAetherRepositorySystem(new HashMap<>() {
+                    {
+                        put("default-dependency", new String[] {"1.0.0", "1.1.0", "2.0.0"});
+                    }
+                })) {
+                    {
+                        setProject(new MavenProjectBuilder()
+                                .withDependencies(singletonList(DependencyBuilder.newBuilder()
+                                        .withGroupId("default-group")
+                                        .withArtifactId("default-dependency")
+                                        .withVersion("1.0.0")
+                                        .build()))
+                                .build());
+                        allowProcessingAllDependencies(this);
+                        setPluginContext(new HashMap<>());
+
+                        setSession(mockMavenSession());
+                        setSearchUri("http://localhost:8080");
+
+                        setLog(new InMemoryTestLogger());
+                    }
+                };
+
+        LocalDateTime now = LocalDateTime.now();
+
+        // Mark version 2.0.0 as a year newer
+        // Don't stub 1.1.0, there's no need to check its version
+        stubResponseFor("default-group", "default-dependency", "1.0.0", now.minusYears(1));
+        stubResponseFor("default-group", "default-dependency", "2.0.0", now);
+
+        mojo.execute();
+
+        assertTrue(((InMemoryTestLogger) mojo.getLog())
+                .infoLogs.stream()
+                        .anyMatch(
+                                (l) -> l.contains("default-group:default-dependency") && l.contains("1.00 libyears")));
+        assertTrue(((InMemoryTestLogger) mojo.getLog()).errorLogs.isEmpty());
+    }
+
+    /** This test checks that the output for dependencies with long names is formatted correctly. */
+    @Test
+    public void dependencyUpdateWithLongNameAvailable() throws Exception {
+        LibYearMojo mojo =
+                new LibYearMojo(mockRepositorySystem(), mockAetherRepositorySystem(new HashMap<>() {
+                    {
+                        put("default-dependency-with-very-very-long-name", new String[] {"1.0.0", "1.1.0", "2.0.0"});
+                    }
+                })) {
+                    {
+                        setProject(new MavenProjectBuilder()
+                                .withDependencies(singletonList(DependencyBuilder.newBuilder()
+                                        .withGroupId("default-group")
+                                        .withArtifactId("default-dependency-with-very-very-long-name")
+                                        .withVersion("1.0.0")
+                                        .build()))
+                                .build());
+                        allowProcessingAllDependencies(this);
+                        setPluginContext(new HashMap<>());
+
+                        setSession(mockMavenSession());
+                        setSearchUri("http://localhost:8080");
+
+                        setLog(new InMemoryTestLogger());
+                    }
+                };
+
+        LocalDateTime now = LocalDateTime.now();
+
+        // Mark version 2.0.0 as a year newer
+        stubResponseFor("default-group", "default-dependency-with-very-very-long-name", "1.0.0", now.minusYears(1));
+        stubResponseFor("default-group", "default-dependency-with-very-very-long-name", "2.0.0", now);
+
+        mojo.execute();
+
+        // TODO: Implement wrapping for libyear output for dependencies with long names
+        // then update this
+        // test
+        assertTrue(((InMemoryTestLogger) mojo.getLog())
+                .infoLogs.stream()
+                        .anyMatch((l) -> l.contains("default-group:default-dependency-with-very-very-long-name")
+                                && l.contains("1.00 libyears")));
+        assertTrue(((InMemoryTestLogger) mojo.getLog()).errorLogs.isEmpty());
+    }
+
+    @Test
+    public void dependencyUpdateAvailableButDependencyIsExcluded() throws Exception {
+        LibYearMojo mojo =
+                new LibYearMojo(mockRepositorySystem(), mockAetherRepositorySystem(new HashMap<>() {
+                    {
+                        put("default-dependency", new String[] {"1.0.0", "2.0.0"});
+                    }
+                })) {
+                    {
+                        setProject(new MavenProjectBuilder()
+                                .withDependencies(singletonList(DependencyBuilder.newBuilder()
+                                        .withGroupId("default-group")
+                                        .withArtifactId("default-dependency")
+                                        .withVersion("1.0.0")
+                                        .build()))
+                                .build());
+                        allowProcessingAllDependencies(this);
+
+                        setVariableValueToObject(
+                                this, "dependencyExcludes", List.of("default-group:default-dependency"));
+
+                        setPluginContext(new HashMap<>());
+
+                        setSession(mockMavenSession());
+                        setSearchUri("http://localhost:8080");
+
+                        setLog(new InMemoryTestLogger());
+                    }
+                };
+
+        // No need to stub output as no API calls should be made
+
+        mojo.execute();
+
+        assertFalse(((InMemoryTestLogger) mojo.getLog())
+                .infoLogs.stream().anyMatch((l) -> l.contains("default-group:default-dependency")));
+        assertTrue(((InMemoryTestLogger) mojo.getLog()).errorLogs.isEmpty());
+    }
+
+    @Test
+    public void dependencyUpdateAvailableButVersionIsIgnored() throws Exception {
+        LibYearMojo mojo =
+                new LibYearMojo(mockRepositorySystem(), mockAetherRepositorySystem(new HashMap<>() {
+                    {
+                        put("default-dependency", new String[] {"1.0.0", "2.0.0"});
+                    }
+                })) {
+                    {
+                        setProject(new MavenProjectBuilder()
+                                .withDependencies(singletonList(DependencyBuilder.newBuilder()
+                                        .withGroupId("default-group")
+                                        .withArtifactId("default-dependency")
+                                        .withVersion("1.0.0")
+                                        .build()))
+                                .build());
+                        allowProcessingAllDependencies(this);
+
+                        setVariableValueToObject(this, "ignoredVersions", Set.of("2.0.0"));
+
+                        setPluginContext(new HashMap<>());
+
+                        setSession(mockMavenSession());
+                        setSearchUri("http://localhost:8080");
+
+                        setLog(new InMemoryTestLogger());
+                    }
+                };
+
+        // No need to stub output as no API calls should be made
+
+        mojo.execute();
+
+        assertFalse(((InMemoryTestLogger) mojo.getLog())
+                .infoLogs.stream().anyMatch((l) -> l.contains("default-group:default-dependency")));
+        assertTrue(((InMemoryTestLogger) mojo.getLog()).errorLogs.isEmpty());
+    }
+
+    @Test
+    public void dependencyUpdateAvailableButProcessingDependenciesIsDisabled() throws Exception {
+        LibYearMojo mojo =
+                new LibYearMojo(mockRepositorySystem(), mockAetherRepositorySystem(new HashMap<>() {
+                    {
+                        put("default-dependency", new String[] {"1.0.0", "1.1.0", "2.0.0"});
+                    }
+                })) {
+                    {
+                        setProject(new MavenProjectBuilder()
+                                .withDependencies(singletonList(DependencyBuilder.newBuilder()
+                                        .withGroupId("default-group")
+                                        .withArtifactId("default-dependency")
+                                        .withVersion("1.0.0")
+                                        .build()))
+                                .build());
+                        allowProcessingAllDependencies(this);
+                        setVariableValueToObject(this, "processDependencies", false);
+
+                        setPluginContext(new HashMap<>());
+
+                        setSession(mockMavenSession());
+                        setSearchUri("http://localhost:8080");
+
+                        setLog(new InMemoryTestLogger());
+                    }
+                };
+
+        LocalDateTime now = LocalDateTime.now();
+
+        // Mark version 2.0.0 as a year newer
+        // Don't stub 1.1.0, there's no need to check its version
+        stubResponseFor("default-group", "default-dependency", "1.0.0", now.minusYears(1));
+        stubResponseFor("default-group", "default-dependency", "2.0.0", now);
+
+        mojo.execute();
+
+        assertFalse(((InMemoryTestLogger) mojo.getLog())
+                .infoLogs.stream().anyMatch((l) -> l.contains("default-group:default-dependency")));
+        assertTrue(((InMemoryTestLogger) mojo.getLog()).errorLogs.isEmpty());
+    }
+
+    /**
+     * The plugin should cache the result of API calls to find the release date of every dependency
+     * that it makes. This test ensures that despite running the plugin twice, we only make one API
+     * call for each dependency version.
+     */
+    @Test
+    public void cacheIsUsedForDependencyVersions() throws Exception {
+        // Run one of the tests twice, which should only trigger one fetch per
+        // dependency version
+        dependencyUpdateAvailable();
+        dependencyUpdateAvailable();
+
+        // One call for v1.0.0
+        verify(
+                1,
+                getRequestedFor(urlPathEqualTo("/solrsearch/select"))
+                        .withQueryParam("q", equalTo("g:default-group AND a:default-dependency AND v:1.0.0")));
+
+        // One call for v2.0.0
+        verify(
+                1,
+                getRequestedFor(urlPathEqualTo("/solrsearch/select"))
+                        .withQueryParam("q", equalTo("g:default-group AND a:default-dependency AND v:2.0.0")));
+    }
+
+    @Test
+    public void dependencyUpdateAvailableWhenVersionSpecifiedInDependencyManagement() throws Exception {
+        LibYearMojo mojo =
+                new LibYearMojo(mockRepositorySystem(), mockAetherRepositorySystem(new HashMap<>() {
+                    {
+                        put("default-dependency", new String[] {"1.0.0", "1.1.0", "2.0.0"});
+                    }
+                })) {
+                    {
+                        setProject(new MavenProjectBuilder()
+                                .withDependencies(singletonList(DependencyBuilder.newBuilder()
+                                        .withGroupId("default-group")
+                                        .withArtifactId("default-dependency")
+                                        .withVersion("1.0.0") // This is
+                                        // overridden by
+                                        // dependencyManagement
+                                        .build()))
+                                .withDependencyManagementDependencyList(singletonList(DependencyBuilder.newBuilder()
+                                        .withGroupId("default-group")
+                                        .withArtifactId("default-dependency")
+                                        .withVersion("1.1.0")
+                                        .build()))
+                                .build());
+                        allowProcessingAllDependencies(this);
+                        setPluginContext(new HashMap<>());
+
+                        setSession(mockMavenSession());
+                        setSearchUri("http://localhost:8080");
+
+                        setLog(new InMemoryTestLogger());
+                    }
+                };
+
+        LocalDateTime now = LocalDateTime.now();
+
+        // Mark version 2.0.0 as a year newer than the version specified by
+        // dependencyManagement
+        stubResponseFor("default-group", "default-dependency", "1.0.0", now.minusYears(2));
+        stubResponseFor("default-group", "default-dependency", "1.1.0", now.minusYears(1));
+        stubResponseFor("default-group", "default-dependency", "2.0.0", now);
+
+        mojo.execute();
+
+        assertTrue(((InMemoryTestLogger) mojo.getLog())
+                .infoLogs.stream()
+                        .anyMatch(
+                                (l) -> l.contains("default-group:default-dependency") && l.contains("1.00 libyears")));
+
+        assertTrue(((InMemoryTestLogger) mojo.getLog()).errorLogs.isEmpty());
+    }
+
+    /**
+     * This test has a project with a dependency with version 1.0.0. Dependency management pins it
+     * at 1.1.0, and 2.0.0 is available. We exclude the plugin from considering dependency
+     * management, meaning we should show the age between 1.0.0 and 2.0.0.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void
+            dependencyUpdateAvailableWhenVersionSpecifiedInDependencyManagementButDependencyExcludedFromDependencyManagement()
+                    throws Exception {
+        LibYearMojo mojo =
+                new LibYearMojo(mockRepositorySystem(), mockAetherRepositorySystem(new HashMap<>() {
+                    {
+                        put("default-dependency", new String[] {"1.0.0", "1.1.0", "2.0.0"});
+                    }
+                })) {
+                    {
+                        setProject(new MavenProjectBuilder()
+                                .withDependencies(singletonList(DependencyBuilder.newBuilder()
+                                        .withGroupId("default-group")
+                                        .withArtifactId("default-dependency")
+                                        .withVersion("1.0.0") // This is
+                                        // overridden by
+                                        // dependencyManagement
+                                        .build()))
+                                .withDependencyManagementDependencyList(singletonList(DependencyBuilder.newBuilder()
+                                        .withGroupId("default-group")
+                                        .withArtifactId("default-dependency")
+                                        .withVersion("1.1.0")
+                                        .build()))
+                                .build());
+                        allowProcessingAllDependencies(this);
+
+                        setVariableValueToObject(
+                                this, "dependencyManagementExcludes", List.of("default-group:default-dependency"));
+
+                        setPluginContext(new HashMap<>());
+
+                        setSession(mockMavenSession());
+                        setSearchUri("http://localhost:8080");
+
+                        setLog(new InMemoryTestLogger());
+                    }
+                };
+
+        LocalDateTime now = LocalDateTime.now();
+
+        // Mark version 2.0.0 as a year newer than the version specified by
+        // dependencyManagement
+        stubResponseFor("default-group", "default-dependency", "1.0.0", now.minusYears(2));
+        stubResponseFor("default-group", "default-dependency", "1.1.0", now.minusYears(1));
+        stubResponseFor("default-group", "default-dependency", "2.0.0", now);
+
+        mojo.execute();
+
+        assertTrue(((InMemoryTestLogger) mojo.getLog())
+                .infoLogs.stream()
+                        .anyMatch(
+                                (l) -> l.contains("default-group:default-dependency") && l.contains("2.00 libyears")));
+
+        assertTrue(((InMemoryTestLogger) mojo.getLog()).errorLogs.isEmpty());
+    }
+
+    /**
+     * This test has a project with a two-year-old dependency where the dependency version is
+     * overridden by the dependencyManagement section to use a one-year-old version, but the plugin
+     * setting enableDependencyManagement is set to false. We should ignore the one-year-old version
+     * and suggest that the dependency is two years out-of-date.
+     */
+    @Test
+    public void
+            dependencyUpdateAvailableWhenVersionSpecifiedInDependencyManagementWhereProcessDependencyManagementIsDisabled()
+                    throws Exception {
+        LibYearMojo mojo =
+                new LibYearMojo(mockRepositorySystem(), mockAetherRepositorySystem(new HashMap<>() {
+                    {
+                        put("default-dependency", new String[] {"1.0.0", "1.1.0", "2.0.0"});
+                    }
+                })) {
+                    {
+                        setProject(new MavenProjectBuilder()
+                                .withDependencies(singletonList(DependencyBuilder.newBuilder()
+                                        .withGroupId("default-group")
+                                        .withArtifactId("default-dependency")
+                                        .withVersion("1.0.0") // This is
+                                        // overridden by
+                                        // dependencyManagement
+                                        .build()))
+                                .withDependencyManagementDependencyList(singletonList(DependencyBuilder.newBuilder()
+                                        .withGroupId("default-group")
+                                        .withArtifactId("default-dependency")
+                                        .withVersion("1.1.0")
+                                        .build()))
+                                .build());
+                        allowProcessingAllDependencies(this);
+                        setVariableValueToObject(this, "processDependencyManagement", false);
+                        setPluginContext(new HashMap<>());
+
+                        setSession(mockMavenSession());
+                        setSearchUri("http://localhost:8080");
+
+                        setLog(new InMemoryTestLogger());
+                    }
+                };
+
+        LocalDateTime now = LocalDateTime.now();
+
+        // Mark version 2.0.0 as a year newer than the version specified by
+        // dependencyManagement
+        stubResponseFor("default-group", "default-dependency", "1.0.0", now.minusYears(2));
+        stubResponseFor("default-group", "default-dependency", "1.1.0", now.minusYears(1));
+        stubResponseFor("default-group", "default-dependency", "2.0.0", now);
+
+        mojo.execute();
+
+        assertTrue(((InMemoryTestLogger) mojo.getLog())
+                .infoLogs.stream()
+                        .anyMatch(
+                                (l) -> l.contains("default-group:default-dependency") && l.contains("2.00 libyears")));
+
+        assertTrue(((InMemoryTestLogger) mojo.getLog()).errorLogs.isEmpty());
+    }
+
+    /**
+     * This test has a dependency with version 1.0.0, which is overridden by dependencyManagement to
+     * 1.1.0. Version 2.0.0 is available.
+     *
+     * <p>We ensure that the proposed change is the libyears between 1.1.0 and 2.0.0.
+     */
+    @Test
+    public void dependencyUpdateAvailableDependencyDefinedInDependencyManagement() throws Exception {
+        LibYearMojo mojo =
+                new LibYearMojo(mockRepositorySystem(), mockAetherRepositorySystem(new HashMap<>() {
+                    {
+                        put("default-dependency", new String[] {"1.0.0", "1.1.0", "2.0.0"});
+                    }
+                })) {
+                    {
+                        setProject(new MavenProjectBuilder()
+                                .withDependencies(singletonList(DependencyBuilder.newBuilder()
+                                        .withGroupId("default-group")
+                                        .withArtifactId("default-dependency")
+                                        .withVersion("1.0.0")
+                                        .build()))
+                                .withDependencyManagementDependencyList(singletonList(DependencyBuilder.newBuilder()
+                                        .withGroupId("default-group")
+                                        .withArtifactId("default-dependency")
+                                        .withVersion("1.1.0")
+                                        .build()))
+                                .build());
+                        allowProcessingAllDependencies(this);
+                        setPluginContext(new HashMap<>());
+
+                        setSession(mockMavenSession());
+                        setSearchUri("http://localhost:8080");
+
+                        setLog(new InMemoryTestLogger());
+                    }
+                };
+
+        LocalDateTime now = LocalDateTime.now();
+
+        // Mark version 2.0.0 as a year newer. The current dependency version is 1.1.0,
+        // overridden from
+        // 1.0.0 by
+        // dependencyManagement
+
+        // TODO: This first stub probably shouldn't be needed as we shouldn't need to
+        // fetch the release
+        // year of this version
+        // but without it, the test fails.
+        stubResponseFor("default-group", "default-dependency", "1.0.0", now.minusYears(10));
+        stubResponseFor("default-group", "default-dependency", "1.1.0", now.minusYears(1));
+        stubResponseFor("default-group", "default-dependency", "2.0.0", now);
+
+        mojo.execute();
+
+        assertTrue(((InMemoryTestLogger) mojo.getLog())
+                .infoLogs.stream()
+                        .anyMatch(
+                                (l) -> l.contains("default-group:default-dependency") && l.contains("1.00 libyears")));
+        assertTrue(((InMemoryTestLogger) mojo.getLog()).errorLogs.isEmpty());
+    }
+
+    @Test
+    public void pluginVersionUpdateAvailable() throws Exception {
+        Plugin plugin = pluginOf("default-plugin", "default-group", "1.0.0");
+        plugin.setDependencies(singletonList(dependencyFor("default-group", "default-dependency", "1.0.0")));
+
+        LibYearMojo mojo =
+                new LibYearMojo(mockRepositorySystem(), mockAetherRepositorySystem(new HashMap<>() {
+                    {
+                        put("default-dependency", new String[] {"1.0.0", "1.1.0", "2.0.0"});
+                    }
+                })) {
+                    {
+                        setProject(new MavenProjectBuilder()
+                                .withPlugins(singletonList(plugin))
+                                .build());
+
+                        allowProcessingAllDependencies(this);
+                        setPluginContext(new HashMap<>());
+
+                        setSession(mockMavenSession());
+                        setSearchUri("http://localhost:8080");
+
+                        setLog(new InMemoryTestLogger());
+                    }
+                };
+
+        LocalDateTime now = LocalDateTime.now();
+
+        // Mark version 2.0.0 as a year newer
+        stubResponseFor("default-group", "default-dependency", "1.0.0", now.minusYears(1));
+        stubResponseFor("default-group", "default-dependency", "2.0.0", now);
+
+        mojo.execute();
+
+        assertTrue(((InMemoryTestLogger) mojo.getLog())
+                .infoLogs.stream()
+                        .anyMatch(
+                                (l) -> l.contains("default-group:default-dependency") && l.contains("1.00 libyears")));
+        assertTrue(((InMemoryTestLogger) mojo.getLog()).errorLogs.isEmpty());
+    }
+
+    /**
+     * This test has a plugin version 1.0.0 which has a dependency on another artifact version
+     * 1.0.1. That version is overridden in dependency management to 1.1.0. Version 2.0.0 is
+     * available.
+     *
+     * <p>This test ensures we suggest the libyears between 1.1.0 and 2.0.0.
+     */
+    @Test
+    public void pluginVersionUpdateAvailableDependencyDefinedInDependencyManagement() throws Exception {
+        Plugin plugin = pluginOf("default-plugin", "default-group", "1.0.0");
+        plugin.setDependencies(singletonList(dependencyFor("default-group", "default-dependency", "1.0.1")));
+
+        LibYearMojo mojo =
+                new LibYearMojo(mockRepositorySystem(), mockAetherRepositorySystem(new HashMap<>() {
+                    {
+                        put("default-dependency", new String[] {"1.0.0", "1.1.0", "2.0.0"});
+                    }
+                })) {
+                    {
+                        setProject(new MavenProjectBuilder()
+                                .withPlugins(singletonList(plugin))
+                                .withDependencyManagementDependencyList(singletonList(DependencyBuilder.newBuilder()
+                                        .withGroupId("default-group")
+                                        .withArtifactId("default-dependency")
+                                        .withVersion("1.1.0")
+                                        .build()))
+                                .build());
+
+                        allowProcessingAllDependencies(this);
+                        setPluginContext(new HashMap<>());
+
+                        setSession(mockMavenSession());
+                        setSearchUri("http://localhost:8080");
+
+                        setLog(new InMemoryTestLogger());
+                    }
+                };
+
+        LocalDateTime now = LocalDateTime.now();
+
+        // Mark version 2.0.0 as a year newer
+        stubResponseFor("default-group", "default-dependency", "1.0.1", now.minusYears(2));
+        stubResponseFor("default-group", "default-dependency", "1.1.0", now.minusYears(1));
+        stubResponseFor("default-group", "default-dependency", "2.0.0", now);
+
+        mojo.execute();
+
+        assertTrue(((InMemoryTestLogger) mojo.getLog())
+                .infoLogs.stream()
+                        .anyMatch(
+                                (l) -> l.contains("default-group:default-dependency") && l.contains("1.00 libyears")));
+        assertTrue(((InMemoryTestLogger) mojo.getLog()).errorLogs.isEmpty());
+    }
+
+    /**
+     * This test has a plugin version 1.0.0. That version is overridden in plugin management to
+     * 1.1.0. Version 2.0.0 is available.
+     *
+     * <p>This test ensures we suggest the libyears between 1.1.0 and 2.0.0.
+     */
+    @Test
+    public void pluginVersionUpdateAvailableDependencyDefinedInPluginManagement() throws Exception {
+        Plugin plugin = pluginOf("default-plugin", "default-group", "1.0.0");
+        plugin.setDependencies(singletonList(dependencyFor("default-group", "default-dependency", "1.0.1")));
+
+        Plugin managedPlugin = pluginOf("default-plugin", "default-group", "1.0.0");
+        plugin.setDependencies(singletonList(dependencyFor("default-group", "default-dependency", "1.1.0")));
+
+        LibYearMojo mojo =
+                new LibYearMojo(mockRepositorySystem(), mockAetherRepositorySystem(new HashMap<>() {
+                    {
+                        put("default-dependency", new String[] {"1.0.0", "1.1.0", "2.0.0"});
+                    }
+                })) {
+                    {
+                        setProject(new MavenProjectBuilder()
+                                .withPlugins(singletonList(plugin))
+                                .withPluginManagementPluginList(singletonList(managedPlugin))
+                                .build());
+
+                        allowProcessingAllDependencies(this);
+
+                        setPluginContext(new HashMap<>());
+
+                        setSession(mockMavenSession());
+                        setSearchUri("http://localhost:8080");
+
+                        setLog(new InMemoryTestLogger());
+                    }
+                };
+
+        LocalDateTime now = LocalDateTime.now();
+
+        // Mark version 2.0.0 as a year newer
+        stubResponseFor("default-group", "default-dependency", "1.1.0", now.minusYears(1));
+        stubResponseFor("default-group", "default-dependency", "2.0.0", now);
+
+        mojo.execute();
+
+        assertTrue(((InMemoryTestLogger) mojo.getLog())
+                .infoLogs.stream()
+                        .anyMatch(
+                                (l) -> l.contains("default-group:default-dependency") && l.contains("1.00 libyears")));
+        assertTrue(((InMemoryTestLogger) mojo.getLog()).errorLogs.isEmpty());
+    }
+
+    private Dependency dependencyFor(String groupID, String artifactId, String version) {
+        Dependency dep = new Dependency();
+        dep.setGroupId(groupID);
+        dep.setArtifactId(artifactId);
+        dep.setVersion(version);
+        return dep;
+    }
+
+    /**
+     * Stub the Maven search API response that looks for release information for a particular
+     * version of a particular artifact
+     */
+    private void stubResponseFor(String groupId, String artifactId, String version, LocalDateTime time) {
+        stubFor(get(urlPathEqualTo("/solrsearch/select"))
+                .withQueryParam("q", equalTo(String.format("g:%s AND a:%s AND v:%s", groupId, artifactId, version)))
+                .withQueryParam("wt", equalTo("json"))
+                .willReturn(ok(getJSONResponseForVersion(groupId, artifactId, version, time))));
+    }
+
+    /**
+     * Simulate the JSON response from the Maven Central repository search API. Docs available at <a
+     * href="https://central.sonatype.org/search/rest-api-guide/">here</a>.
+     */
+    private String getJSONResponseForVersion(
+            String groupId, String artifactId, String version, LocalDateTime releaseDate) {
+        JSONObject root = new JSONObject();
+        JSONObject response = new JSONObject();
+        JSONArray versions = new JSONArray();
+        JSONObject newVersion = new JSONObject();
+
+        newVersion.put("id", String.format("%s:%s:%s", groupId, artifactId, version));
+        newVersion.put("g", groupId);
+        newVersion.put("a", artifactId);
+        newVersion.put("v", version);
+        newVersion.put("p", "jar");
+        newVersion.put("timestamp", releaseDate.toEpochSecond(ZoneOffset.UTC) * 1000); // API response is in millis
+
+        versions.put(newVersion);
+        response.put("docs", versions);
+        response.put("numFound", 1);
+        root.put("response", response);
+
+        return root.toString();
+    }
+
+    @Test
+    public void apiCallToMavenFails() throws Exception {
+        LibYearMojo mojo =
+                new LibYearMojo(mockRepositorySystem(), mockAetherRepositorySystem(new HashMap<>() {
+                    {
+                        put("default-dependency", new String[] {"1.0.0", "2.0.0"});
+                    }
+                })) {
+                    {
+                        setProject(new MavenProjectBuilder()
+                                .withDependencies(singletonList(DependencyBuilder.newBuilder()
+                                        .withGroupId("default-group")
+                                        .withArtifactId("default-dependency")
+                                        .withVersion("1.0.0")
+                                        .build()))
+                                .build());
+                        allowProcessingAllDependencies(this);
+                        setPluginContext(new HashMap<>());
+
+                        setSession(mockMavenSession());
+                        setSearchUri("http://localhost:8080");
+
+                        setLog(new InMemoryTestLogger());
+                    }
+                };
+
+        stubFor(get(urlPathEqualTo("/solrsearch/select")).willReturn(serverError()));
+
+        mojo.execute();
+
+        assertTrue(((InMemoryTestLogger) mojo.getLog())
+                .errorLogs.stream()
+                        .anyMatch((l) -> l.contains(
+                                "Failed to fetch release date for" + " default-group:default-dependency" + " 1.0.0")));
+        assertTrue(((InMemoryTestLogger) mojo.getLog())
+                .errorLogs.stream()
+                        .anyMatch((l) -> l.contains(
+                                "Failed to fetch release date for" + " default-group:default-dependency" + " 2.0.0")));
+    }
+
+    @Test
+    public void apiCallToMavenTimesOut() throws Exception {
+        LibYearMojo mojo =
+                new LibYearMojo(mockRepositorySystem(), mockAetherRepositorySystem(new HashMap<>() {
+                    {
+                        put("default-dependency", new String[] {"1.0.0", "2.0.0"});
+                    }
+                })) {
+                    {
+                        setProject(new MavenProjectBuilder()
+                                .withDependencies(singletonList(DependencyBuilder.newBuilder()
+                                        .withGroupId("default-group")
+                                        .withArtifactId("default-dependency")
+                                        .withVersion("1.0.0")
+                                        .build()))
+                                .build());
+                        allowProcessingAllDependencies(this);
+                        setPluginContext(new HashMap<>());
+
+                        setSession(mockMavenSession());
+                        setSearchUri("http://localhost:8080");
+                        setHttpTimeout(1);
+                        setFetchRetryCount(0);
+
+                        setLog(new InMemoryTestLogger());
+                    }
+                };
+
+        stubFor(get(urlPathEqualTo("/solrsearch/select")).willReturn(ok().withFixedDelay(10_000 /* ms */)));
+
+        mojo.execute();
+
+        assertTrue(((InMemoryTestLogger) mojo.getLog())
+                .errorLogs.stream()
+                        .anyMatch((l) -> l.contains("Failed to fetch release date for"
+                                + " default-group:default-dependency"
+                                + " 1.0.0 (request timed out)")));
+        assertTrue(((InMemoryTestLogger) mojo.getLog())
+                .errorLogs.stream()
+                        .anyMatch((l) -> l.contains("Failed to fetch release date for"
+                                + " default-group:default-dependency"
+                                + " 2.0.0 (request timed out)")));
+        assertEquals(2, ((InMemoryTestLogger) mojo.getLog()).errorLogs.size());
+    }
+
+    @Test
+    public void apiCallToMavenRetriesOnFailure() throws Exception {
+        LibYearMojo mojo =
+                new LibYearMojo(mockRepositorySystem(), mockAetherRepositorySystem(new HashMap<>() {
+                    {
+                        put("default-dependency", new String[] {"1.0.0", "2.0.0"});
+                    }
+                })) {
+                    {
+                        setProject(new MavenProjectBuilder()
+                                .withDependencies(singletonList(DependencyBuilder.newBuilder()
+                                        .withGroupId("default-group")
+                                        .withArtifactId("default-dependency")
+                                        .withVersion("1.0.0")
+                                        .build()))
+                                .build());
+                        allowProcessingAllDependencies(this);
+                        setPluginContext(new HashMap<>());
+
+                        setSession(mockMavenSession());
+                        setSearchUri("http://localhost:8080");
+
+                        setFetchRetryCount(2);
+
+                        setLog(new InMemoryTestLogger());
+                    }
+                };
+
+        LocalDateTime now = LocalDateTime.now();
+
+        // The first dependency should fail twice and return OK on the second retry
+        stubFor(get(urlPathEqualTo("/solrsearch/select"))
+                .withQueryParam(
+                        "q",
+                        equalTo(String.format(
+                                "g:%s AND a:%s AND v:%s", "default-group", "default-dependency", "1.0.0")))
+                .inScenario("Failure chain")
+                .whenScenarioStateIs("Started")
+                .willReturn(serverError())
+                .willSetStateTo("First failure"));
+
+        stubFor(get(urlPathEqualTo("/solrsearch/select"))
+                .inScenario("Failure chain")
+                .whenScenarioStateIs("First failure")
+                .willReturn(serverError())
+                .willSetStateTo("Second failure"));
+
+        stubFor(get(urlPathEqualTo("/solrsearch/select"))
+                .inScenario("Failure chain")
+                .whenScenarioStateIs("Second failure")
+                .willReturn(ok(
+                        getJSONResponseForVersion("default-group", "default-dependency", "1.0.0", now.minusYears(1)))));
+
+        // The second request will succeed first time
+        stubResponseFor("default-group", "default-dependency", "2.0.0", now);
+
+        mojo.execute();
+
+        assertTrue(((InMemoryTestLogger) mojo.getLog())
+                .infoLogs.stream()
+                        .anyMatch(
+                                (l) -> l.contains("default-group:default-dependency") && l.contains("1.00 libyears")));
+    }
+
+    @Test
+    public void dependencyUpdateAvailableButFetchingReleaseDateOfNewerVersionFails() throws Exception {
+        LibYearMojo mojo =
+                new LibYearMojo(mockRepositorySystem(), mockAetherRepositorySystem(new HashMap<>() {
+                    {
+                        put("default-dependency", new String[] {"1.0.0", "1.1.0", "2.0.0"});
+                    }
+                })) {
+                    {
+                        setProject(new MavenProjectBuilder()
+                                .withDependencies(singletonList(DependencyBuilder.newBuilder()
+                                        .withGroupId("default-group")
+                                        .withArtifactId("default-dependency")
+                                        .withVersion("1.0.0")
+                                        .build()))
+                                .build());
+
+                        allowProcessingAllDependencies(this);
+
+                        setPluginContext(new HashMap<>());
+
+                        setSession(mockMavenSession());
+                        setSearchUri("http://localhost:8080");
+
+                        setLog(new InMemoryTestLogger());
+                    }
+                };
+
+        LocalDateTime now = LocalDateTime.now();
+
+        stubResponseFor("default-group", "default-dependency", "1.0.0", now.minusYears(1));
+        stubFor(get(urlPathEqualTo("/solrsearch/select"))
+                .withQueryParam(
+                        "q",
+                        equalTo(String.format(
+                                "g:%s AND a:%s AND v:%s", "default-group", "default-dependency", "2.0.0")))
+                .withQueryParam("wt", equalTo("json"))
+                .willReturn(serverError()));
+
+        mojo.execute();
+
+        assertFalse(((InMemoryTestLogger) mojo.getLog())
+                .infoLogs.stream().anyMatch((l) -> l.contains("default-group:default-dependency")));
+        assertTrue(((InMemoryTestLogger) mojo.getLog())
+                .errorLogs.contains(
+                        "Failed to fetch release date for default-group:default-dependency" + " 2.0.0: Server Error"));
+    }
+
+    @Test
+    public void dependencyUpdateAvailableButAPISearchDoesNotContainLatestVersion() throws Exception {
+        LibYearMojo mojo =
+                new LibYearMojo(mockRepositorySystem(), mockAetherRepositorySystem(new HashMap<>() {
+                    {
+                        put("default-dependency", new String[] {"1.0.0", "1.1.0", "2.0.0"});
+                    }
+                })) {
+                    {
+                        setProject(new MavenProjectBuilder()
+                                .withDependencies(singletonList(DependencyBuilder.newBuilder()
+                                        .withGroupId("default-group")
+                                        .withArtifactId("default-dependency")
+                                        .withVersion("1.0.0")
+                                        .build()))
+                                .build());
+                        allowProcessingAllDependencies(this);
+                        setPluginContext(new HashMap<>());
+
+                        setSession(mockMavenSession());
+                        setSearchUri("http://localhost:8080");
+
+                        setLog(new InMemoryTestLogger());
+                    }
+                };
+
+        LocalDateTime now = LocalDateTime.now();
+
+        stubResponseFor("default-group", "default-dependency", "1.0.0", now.minusYears(1));
+        stubFor(get(urlPathEqualTo("/solrsearch/select"))
+                .withQueryParam(
+                        "q",
+                        equalTo(String.format(
+                                "g:%s AND a:%s AND v:%s", "default-group", "default-dependency", "2.0.0")))
+                .withQueryParam("wt", equalTo("json"))
+                .willReturn(ok("{\"response\":{\"docs\":[],\"numFound\":0}}")));
+
+        mojo.execute();
+
+        assertFalse(((InMemoryTestLogger) mojo.getLog())
+                .infoLogs.stream().anyMatch((l) -> l.contains("default-group:default-dependency")));
+        assertTrue(((InMemoryTestLogger) mojo.getLog())
+                .debugLogs.contains("Could not find artifact for default-group:default-dependency" + " 2.0.0"));
+    }
+
+    @Test
+    public void multipleDependenciesWithUpdatesAreSortedAlphabetically() throws Exception {
+        LibYearMojo mojo =
+                new LibYearMojo(mockRepositorySystem(), mockAetherRepositorySystem(new HashMap<>() {
+                    {
+                        put("default-dependency", new String[] {"1.0.0", "2.0.0"});
+                        put("second-dependency", new String[] {"5.0.0", "6.0.0"});
+                    }
+                })) {
+                    {
+                        setProject(new MavenProjectBuilder()
+                                .withDependencies(List.of(
+                                        DependencyBuilder.newBuilder()
+                                                .withGroupId("default-group")
+                                                .withArtifactId("second-dependency")
+                                                .withVersion("5.0.0")
+                                                .build(),
+                                        DependencyBuilder.newBuilder()
+                                                .withGroupId("default-group")
+                                                .withArtifactId("default-dependency")
+                                                .withVersion("1.0.0")
+                                                .build()))
+                                .build());
+                        allowProcessingAllDependencies(this);
+                        setPluginContext(new HashMap<>());
+
+                        setSession(mockMavenSession());
+                        setSearchUri("http://localhost:8080");
+
+                        setLog(new InMemoryTestLogger());
+                    }
+                };
+
+        LocalDateTime now = LocalDateTime.now();
+
+        // Mark version 2.0.0 as a year newer
+        // Don't stub 1.1.0, there's no need to check its version
+        stubResponseFor("default-group", "default-dependency", "1.0.0", now.minusYears(1));
+        stubResponseFor("default-group", "default-dependency", "2.0.0", now);
+        stubResponseFor("default-group", "second-dependency", "5.0.0", now.minusYears(5));
+        stubResponseFor("default-group", "second-dependency", "6.0.0", now.minusYears(3));
+
+        mojo.execute();
+
+        List<String> infoLogs = ((InMemoryTestLogger) mojo.getLog()).infoLogs;
+        String firstLogInvolvingDefaultGroup = infoLogs.stream()
+                .filter(l -> l.contains("default-group"))
+                .findFirst()
+                .get();
+        int indexOfFirstLog = infoLogs.indexOf(firstLogInvolvingDefaultGroup);
+        assertTrue(infoLogs.get(indexOfFirstLog + 1).contains("second-dependency"));
+        assertTrue(((InMemoryTestLogger) mojo.getLog()).errorLogs.isEmpty());
+    }
+
+    @Test
+    public void projectExceedsMaxLibYearsAndShouldFailTheBuild() throws Exception {
+        LibYearMojo mojo =
+                new LibYearMojo(mockRepositorySystem(), mockAetherRepositorySystem(new HashMap<>() {
+                    {
+                        put("default-dependency", new String[] {"1.0.0", "2.0.0"});
+                    }
+                })) {
+                    {
+                        setProject(new MavenProjectBuilder()
+                                .withDependencies(singletonList(DependencyBuilder.newBuilder()
+                                        .withGroupId("default-group")
+                                        .withArtifactId("default-dependency")
+                                        .withVersion("1.0.0")
+                                        .build()))
+                                .build());
+                        allowProcessingAllDependencies(this);
+
+                        setVariableValueToObject(this, "maxLibYears", 0.1f);
+
+                        setPluginContext(new HashMap<>());
+
+                        setSession(mockMavenSession());
+                        setSearchUri("http://localhost:8080");
+
+                        setLog(new InMemoryTestLogger());
+                    }
+                };
+
+        LocalDateTime now = LocalDateTime.now();
+
+        stubResponseFor("default-group", "default-dependency", "1.0.0", now.minusYears(1));
+        stubResponseFor("default-group", "default-dependency", "2.0.0", now);
+
+        MojoExecutionException ex = assertThrows(MojoExecutionException.class, mojo::execute);
+        assertEquals("Dependencies exceed maximum specified age in libyears", ex.getMessage());
+
+        assertTrue(((InMemoryTestLogger) mojo.getLog())
+                .errorLogs.stream()
+                        .anyMatch(l ->
+                                l.contains("This project exceeds the maximum" + " dependency age of 0.1 libyears")));
+    }
+
+    private void allowProcessingAllDependencies(LibYearMojo mojo) throws IllegalAccessException {
+        setVariableValueToObject(mojo, "ignoredVersions", emptySet());
+        setVariableValueToObject(mojo, "processDependencies", true);
+        setVariableValueToObject(mojo, "processPluginDependencies", true);
+        setVariableValueToObject(mojo, "pluginDependencyIncludes", singletonList(WildcardMatcher.WILDCARD));
+        setVariableValueToObject(mojo, "pluginDependencyExcludes", emptyList());
+        setVariableValueToObject(mojo, "processPluginDependenciesInPluginManagement", true);
+        setVariableValueToObject(mojo, "pluginManagementDependencyIncludes", singletonList(WildcardMatcher.WILDCARD));
+        setVariableValueToObject(mojo, "pluginManagementDependencyExcludes", emptyList());
+        setVariableValueToObject(mojo, "processDependencyManagement", true);
+        setVariableValueToObject(mojo, "dependencyManagementIncludes", singletonList(WildcardMatcher.WILDCARD));
+        setVariableValueToObject(mojo, "dependencyManagementExcludes", emptyList());
+        setVariableValueToObject(mojo, "dependencyIncludes", singletonList(WildcardMatcher.WILDCARD));
+        setVariableValueToObject(mojo, "dependencyExcludes", emptyList());
+    }
 }

--- a/src/test/java/com/mfoot/mojo/libyear/MavenProjectBuilder.java
+++ b/src/test/java/com/mfoot/mojo/libyear/MavenProjectBuilder.java
@@ -16,6 +16,8 @@
 
 package com.mfoot.mojo.libyear;
 
+import java.util.Collections;
+import java.util.List;
 import org.apache.maven.model.Build;
 import org.apache.maven.model.Dependency;
 import org.apache.maven.model.DependencyManagement;
@@ -24,65 +26,64 @@ import org.apache.maven.model.Plugin;
 import org.apache.maven.model.PluginManagement;
 import org.apache.maven.project.MavenProject;
 
-import java.util.Collections;
-import java.util.List;
-
 class MavenProjectBuilder {
 
-	private List<Dependency> dependencyList = Collections.emptyList();
+    private List<Dependency> dependencyList = Collections.emptyList();
 
-	private List<Plugin> pluginList = Collections.emptyList();
+    private List<Plugin> pluginList = Collections.emptyList();
 
-	private List<Dependency> dependencyManagementDependencyList = Collections.emptyList();
+    private List<Dependency> dependencyManagementDependencyList = Collections.emptyList();
 
-	private List<Plugin> pluginManagementPluginList = Collections.emptyList();
+    private List<Plugin> pluginManagementPluginList = Collections.emptyList();
 
-	public MavenProjectBuilder withDependencies(List<Dependency> dependencyList) {
-		this.dependencyList = dependencyList;
-		return this;
-	}
+    public MavenProjectBuilder withDependencies(List<Dependency> dependencyList) {
+        this.dependencyList = dependencyList;
+        return this;
+    }
 
-	public MavenProjectBuilder withPlugins(List<Plugin> pluginList) {
-		this.pluginList = pluginList;
-		return this;
-	}
+    public MavenProjectBuilder withPlugins(List<Plugin> pluginList) {
+        this.pluginList = pluginList;
+        return this;
+    }
 
-	public MavenProjectBuilder withDependencyManagementDependencyList(List<Dependency> dependencyList) {
-		this.dependencyManagementDependencyList = dependencyList;
-		return this;
-	}
+    public MavenProjectBuilder withDependencyManagementDependencyList(List<Dependency> dependencyList) {
+        this.dependencyManagementDependencyList = dependencyList;
+        return this;
+    }
 
-	public MavenProjectBuilder withPluginManagementPluginList(List<Plugin> pluginList) {
-		this.pluginManagementPluginList = pluginList;
-		return this;
-	}
+    public MavenProjectBuilder withPluginManagementPluginList(List<Plugin> pluginList) {
+        this.pluginManagementPluginList = pluginList;
+        return this;
+    }
 
-	public MavenProject build() {
-		Model model = new Model() {{
-			setGroupId("default-group");
-			setArtifactId("default-artifact");
-			setVersion("1.0.0-SNAPSHOT");
+    public MavenProject build() {
+        Model model = new Model() {
+            {
+                setGroupId("default-group");
+                setArtifactId("default-artifact");
+                setVersion("1.0.0-SNAPSHOT");
 
-			setDependencies(dependencyList);
+                setDependencies(dependencyList);
 
-			Build build = new Build();
-			setBuild(build);
+                Build build = new Build();
+                setBuild(build);
 
-			build.setPlugins(pluginList);
+                build.setPlugins(pluginList);
 
-			PluginManagement pluginManagement = new PluginManagement();
-			build.setPluginManagement(pluginManagement);
-			pluginManagement.setPlugins(pluginManagementPluginList);
+                PluginManagement pluginManagement = new PluginManagement();
+                build.setPluginManagement(pluginManagement);
+                pluginManagement.setPlugins(pluginManagementPluginList);
 
-			DependencyManagement dependencyManagement = new DependencyManagement();
-			setDependencyManagement(dependencyManagement);
-			dependencyManagement.setDependencies(dependencyManagementDependencyList);
-		}};
+                DependencyManagement dependencyManagement = new DependencyManagement();
+                setDependencyManagement(dependencyManagement);
+                dependencyManagement.setDependencies(dependencyManagementDependencyList);
+            }
+        };
 
-		MavenProject project = new MavenProject();
-		project.setModel(model);
-		project.setOriginalModel(model);
+        MavenProject project = new MavenProject();
+        project.setModel(model);
+        project.setOriginalModel(model);
 
-		return project;
-	}
+        return project;
+    }
 }


### PR DESCRIPTION
Adds the [Spotless Maven Plugin](https://github.com/diffplug/spotless/tree/main/plugin-maven) to do code formatting. Uses the [Palantir java code format](https://github.com/palantir/palantir-java-format).

The plugin is bound to the compile phase, so any local build will run the formatter.