### PR TITLE
Rename groupId to com.github.mfoo

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This plugin helps you see how outdated your Maven project dependencies are via t
 [libyear](https://libyear.com/) dependency freshness measure:
 
 ```
-[INFO] -------------------< com.mfoot:libyear-maven-plugin >-------------------
+[INFO] -------------------< com.github.mfoo:libyear-maven-plugin >-------------------
 [INFO] Building libyear-maven-plugin Maven Mojo 0.0.1-SNAPSHOT
 [INFO] ----------------------------[ maven-plugin ]----------------------------
 [INFO]
@@ -33,7 +33,7 @@ a build inside `pom.xml`.
 ### Command-line
 
 ```shell
-mvn com.mfoot:libyear-maven-plugin:0.0.1-SNAPSHOT:analyze
+mvn com.github.mfoo:libyear-maven-plugin:0.0.1-SNAPSHOT:analyze
 ```
 
 ### Plugin execution
@@ -42,7 +42,7 @@ mvn com.mfoot:libyear-maven-plugin:0.0.1-SNAPSHOT:analyze
 <build>
   <plugins>
     <plugin>
-      <groupId>com.mfoot</groupId>
+      <groupId>com.github.mfoo</groupId>
       <artifactId>libyear-maven-plugin</artifactId>
       <version>0.0.1-SNAPSHOT</version>
       <executions>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
 		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
-	<groupId>com.mfoot</groupId>
+	<groupId>com.github.mfoo</groupId>
 	<artifactId>libyear-maven-plugin</artifactId>
 	<packaging>maven-plugin</packaging>
 	<version>0.0.1-SNAPSHOT</version>

--- a/src/main/java/com/github/mfoo/libyear/LibYearMojo.java
+++ b/src/main/java/com/github/mfoo/libyear/LibYearMojo.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.mfoot.mojo.libyear;
+package com.github.mfoo.libyear;
 
 import static java.util.Collections.emptySet;
 import static org.codehaus.mojo.versions.filtering.DependencyFilter.filterDependencies;

--- a/src/test/java/com/github/mfoo/libyear/InMemoryTestLogger.java
+++ b/src/test/java/com/github/mfoo/libyear/InMemoryTestLogger.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.mfoot.mojo.libyear;
+package com.github.mfoo.libyear;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/src/test/java/com/github/mfoo/libyear/LibYearMojoTest.java
+++ b/src/test/java/com/github/mfoo/libyear/LibYearMojoTest.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.mfoot.mojo.libyear;
+package com.github.mfoo.libyear;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;

--- a/src/test/java/com/github/mfoo/libyear/MavenProjectBuilder.java
+++ b/src/test/java/com/github/mfoo/libyear/MavenProjectBuilder.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.mfoot.mojo.libyear;
+package com.github.mfoo.libyear;
 
 import java.util.Collections;
 import java.util.List;


### PR DESCRIPTION
Since this project is hosted on GitHub, the package name should point people back to this project for documentation and code sources.