### PR TITLE
Remove the maven-compat dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,12 +62,6 @@
 			<scope>provided</scope>
 		</dependency>
 		<dependency>
-			<groupId>org.apache.maven</groupId>
-			<artifactId>maven-compat</artifactId>
-			<version>${maven.dependencies.version}</version>
-			<scope>provided</scope>
-		</dependency>
-		<dependency>
 			<groupId>org.codehaus.mojo.versions</groupId>
 			<artifactId>versions-common</artifactId>
 			<version>${codehaus.versions.dependencies.version}</version>


### PR DESCRIPTION
This doesn't seem to be needed.

Docs: https://maven.apache.org/ref/3.8.7/maven-compat/

> Plugins should avoid these classes and be updated to use only Maven3 dependencies (and require Maven3)

