### PR TITLE
Use a shared Apache HttpClient instance

### DIFF
--- a/src/main/java/com/github/mfoo/libyear/LibYearMojo.java
+++ b/src/main/java/com/github/mfoo/libyear/LibYearMojo.java
@@ -102,7 +102,7 @@ public class LibYearMojo extends AbstractMojo {
     private static int MAVEN_API_HTTP_RETRY_COUNT = 5;
 
     /** HTTP timeout for making calls to {@link #SEARCH_URI} */
-    private static int MAVEN_API_HTTP_TIMEOUT_SECONDS = 2;
+    private static int MAVEN_API_HTTP_TIMEOUT_SECONDS = 5;
 
     /** API endpoint to query dependency release dates for age calculations. */
     // TODO: Consider users requiring HTTP proxies

--- a/src/test/java/com/github/mfoo/libyear/LibYearMojoTest.java
+++ b/src/test/java/com/github/mfoo/libyear/LibYearMojoTest.java
@@ -64,12 +64,8 @@ import org.mockito.quality.Strictness;
 @MockitoSettings(strictness = Strictness.LENIENT)
 @WireMockTest(httpPort = 8080)
 public class LibYearMojoTest {
-
     // TODO: Tests with version numbers being referenced by variables
     // TODO: Test with version ranges
-    // TODO: Cleanup
-    // TODO: Run code formatter via plugin and enforce format
-    // TODO: This file is using spaces, not tabs
 
     /**
      * Test factory method. Generates a Plugin object representing the specified parameters.


### PR DESCRIPTION
The plugin makes lots of requests so it makes sense to reuse the client for performance reasons. This commit also adds a thread-safe connection pool.