### PR TITLE
Fix issue where summary line appears on all but the first module in a…

### DIFF
--- a/src/main/java/com/github/mfoo/libyear/LibYearMojo.java
+++ b/src/main/java/com/github/mfoo/libyear/LibYearMojo.java
@@ -607,7 +607,6 @@ public class LibYearMojo extends AbstractMojo {
 
         float[] yearsOutdated = {0};
 
-        getLog().info("");
         getLog().info("The following dependencies in " + pomSection + " have newer versions:");
         validOutdatedDependencies.entrySet().stream()
                 .sorted(Map.Entry.comparingByKey())
@@ -743,7 +742,7 @@ public class LibYearMojo extends AbstractMojo {
      * @return Whether this is the last project to be analysed by the plugin
      */
     private boolean isLastProjectInReactor() {
-        return readyProjectsCounter.incrementAndGet() != session.getProjects().size();
+        return readyProjectsCounter.incrementAndGet() == session.getProjects().size();
     }
 
     private static class RetryAllExceptionsLoggingHandler extends DefaultHttpRequestRetryHandler {


### PR DESCRIPTION
… multi-module project

Currently, in a multi-line module, the summary line appears on all but the first module. This change fixes that behaviour so it only shows on the last project in the reactor (and not if it's a single-module project).