### PR TITLE
Refactor groupId from com.github.mfoo to io.github.mfoo

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This plugin helps you see how outdated your Maven project dependencies are via t
 [libyear](https://libyear.com/) dependency freshness measure:
 
 ```
-[INFO] -------------------< com.github.mfoo:libyear-maven-plugin >-------------------
+[INFO] -------------------< io.github.mfoo:libyear-maven-plugin >-------------------
 [INFO] Building libyear-maven-plugin Maven Mojo 0.0.1-SNAPSHOT
 [INFO] ----------------------------[ maven-plugin ]----------------------------
 [INFO]
@@ -33,7 +33,7 @@ a build inside `pom.xml`.
 ### Command-line
 
 ```shell
-mvn com.github.mfoo:libyear-maven-plugin:0.0.1-SNAPSHOT:analyze
+mvn io.github.mfoo:libyear-maven-plugin:0.0.1-SNAPSHOT:analyze
 ```
 
 ### Plugin execution
@@ -42,7 +42,7 @@ mvn com.github.mfoo:libyear-maven-plugin:0.0.1-SNAPSHOT:analyze
 <build>
   <plugins>
     <plugin>
-      <groupId>com.github.mfoo</groupId>
+      <groupId>io.github.mfoo</groupId>
       <artifactId>libyear-maven-plugin</artifactId>
       <version>0.0.1-SNAPSHOT</version>
       <executions>

--- a/pom.xml
+++ b/pom.xml
@@ -3,9 +3,9 @@
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
-	<groupId>com.github.mfoo</groupId>
+	<groupId>io.github.mfoo</groupId>
 	<artifactId>libyear-maven-plugin</artifactId>
-	<version>0.0.1</version>
+	<version>0.0.1-SNAPSHOT</version>
 	<name>libyear-maven-plugin Maven Mojo</name>
 	<description>This plugin helps you see how outdated your Maven project
 		dependencies are via the libyear dependency freshness measure.</description>

--- a/src/main/java/io/github/mfoo/libyear/LibYearMojo.java
+++ b/src/main/java/io/github/mfoo/libyear/LibYearMojo.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.github.mfoo.libyear;
+package io.github.mfoo.libyear;
 
 import static java.util.Collections.emptySet;
 import static org.codehaus.mojo.versions.filtering.DependencyFilter.filterDependencies;

--- a/src/test/java/io/github/mfoo/libyear/InMemoryTestLogger.java
+++ b/src/test/java/io/github/mfoo/libyear/InMemoryTestLogger.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.github.mfoo.libyear;
+package io.github.mfoo.libyear;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/src/test/java/io/github/mfoo/libyear/LibYearMojoTest.java
+++ b/src/test/java/io/github/mfoo/libyear/LibYearMojoTest.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.github.mfoo.libyear;
+package io.github.mfoo.libyear;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;

--- a/src/test/java/io/github/mfoo/libyear/MavenProjectBuilder.java
+++ b/src/test/java/io/github/mfoo/libyear/MavenProjectBuilder.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.github.mfoo.libyear;
+package io.github.mfoo.libyear;
 
 import java.util.Collections;
 import java.util.List;


### PR DESCRIPTION
This is part of the Sonatype requirements for publishing packages to Maven central