### PR TITLE
Check if optional values are present before using.

### DIFF
--- a/src/main/java/io/github/mfoo/libyear/LibYearMojo.java
+++ b/src/main/java/io/github/mfoo/libyear/LibYearMojo.java
@@ -528,25 +528,17 @@ public class LibYearMojo extends AbstractMojo {
     /**
      * Log the total age, most outdated project and the most outdated dependency of the entire project.
      */
-    @SuppressWarnings("OptionalGetWithoutIsPresent")
     private void logProjectSummary() {
         getLog().info("");
         getLog().info(String.format("The project as a whole is %.2f libyears behind", libWeeksOutDated.get() / 52f));
 
-        Map.Entry<String, Float> oldestProject = projectAges.entrySet().stream()
-                .max(Map.Entry.comparingByValue())
-                .get();
+        projectAges.entrySet().stream().max(Map.Entry.comparingByValue()).ifPresent(module -> getLog().info(
+                        String.format(
+                                "The oldest module is %s (%.2f libyears behind)", module.getKey(), module.getValue())));
 
-        getLog().info(String.format(
-                "The oldest module is %s (%.2f libyears behind)", oldestProject.getKey(), oldestProject.getValue()));
-
-        Map.Entry<String, Float> oldestDependency = dependencyAges.entrySet().stream()
-                .max(Map.Entry.comparingByValue())
-                .get();
-
-        getLog().info(String.format(
-                "The oldest dependency is %s (%.2f libyears behind)",
-                oldestDependency.getKey(), oldestDependency.getValue()));
+        dependencyAges.entrySet().stream().max(Map.Entry.comparingByValue()).ifPresent(dep -> getLog().info(
+                        String.format(
+                                "The oldest dependency is %s (%.2f libyears behind)", dep.getKey(), dep.getValue())));
     }
 
     private VersionsHelper getHelper() throws MojoExecutionException {


### PR DESCRIPTION
Technically unnecessary as we're guaranteed to have a value here, but SonarQube and IDEs don't know that.

This should fix the two "Bug" level issues in SonarCloud that are currently causing the quality gate to fail.