### PR TITLE
Move <dependencyManagement> to Maven Central from GitHub Packages

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,10 +18,13 @@
 	</issueManagement>
 
 	<distributionManagement>
+		<snapshotRepository>
+			<id>ossrh</id>
+			<url>https://s01.oss.sonatype.org/content/repositories/snapshots</url>
+		</snapshotRepository>
 		<repository>
-			<id>github</id>
-			<name>GitHub Packages</name>
-			<url>https://maven.pkg.github.com/mfoo/libyear-maven-plugin</url>
+			<id>ossrh</id>
+			<url>https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/</url>
 		</repository>
 	</distributionManagement>
 


### PR DESCRIPTION
It turns out that the GitHub Packages maven repository isn't publicly accessible.