### PR TITLE
chore(ci): update the JDKs used for tests to the LTS JDK versions

### DIFF
--- a/.github/workflows/maven-tests.yml
+++ b/.github/workflows/maven-tests.yml
@@ -6,7 +6,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-22.04]
-        java: [11, 17, 18]
+        java: [11, 17, 21]
       fail-fast: false
     name: Test on JDK ${{ matrix.java }}, ${{ matrix.os }}
 


### PR DESCRIPTION
This MR bumps the test JDKs to the current LTS releases. Effectively it drops 18 and adds 21.