### PR TITLE
chore(ci): bump build image to latest Ubuntu LTS release

### DIFF
--- a/.github/workflows/maven-tests.yml
+++ b/.github/workflows/maven-tests.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-22.04]
+        os: [ubuntu-24.04]
         java: [11, 17, 21]
       fail-fast: false
     name: Test on JDK ${{ matrix.java }}, ${{ matrix.os }}


### PR DESCRIPTION
Bump the build image from `ubuntu:22.04` to the latest LTS version, `ubuntu:24.04`