### PR TITLE
fix: upgrade Apache HTTP Client from 4 -> 5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -143,14 +143,19 @@
 			<version>33.4.8-jre</version>
 		</dependency>
 		<dependency>
-			<groupId>org.apache.httpcomponents</groupId>
-			<artifactId>httpclient</artifactId>
-			<version>4.5.14</version>
+			<groupId>org.apache.httpcomponents.client5</groupId>
+			<artifactId>httpclient5</artifactId>
+			<version>5.3.1</version>
 		</dependency>
 		<dependency>
-			<groupId>org.apache.httpcomponents</groupId>
-			<artifactId>httpcore</artifactId>
-			<version>4.4.16</version>
+			<groupId>org.apache.httpcomponents.client5</groupId>
+			<artifactId>httpclient5</artifactId>
+			<version>5.3.1</version>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.httpcomponents.core5</groupId>
+			<artifactId>httpcore5</artifactId>
+			<version>5.2.4</version>
 		</dependency>
 		<dependency>
 			<groupId>org.codehaus.plexus</groupId>


### PR DESCRIPTION
This MR replaces the Apache HTTP Client v4 with v5 per the [upgrade guide](https://hc.apache.org/httpcomponents-client-5.5.x/migration-guide/preparation.html).

It also adds an additional test case for a minor coverage improvement (error handling).