### PR TITLE
chore: add Mockito as a java agent during tests to preserve future JDK compatibility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,6 +62,7 @@
 		<maven.dependencies.version>3.9.10</maven.dependencies.version>
 		<codehaus.versions.dependencies.version>2.18.0</codehaus.versions.dependencies.version>
 		<junit.jupiter.version>5.13.1</junit.jupiter.version>
+		<mockito.version>5.18.0</mockito.version>
 		<github.global.server>github</github.global.server>
 
 		<!-- For https://sonarcloud.io/project/overview?id=mfoo_libyear-maven-plugin -->
@@ -202,13 +203,13 @@
 		<dependency>
 			<groupId>org.mockito</groupId>
 			<artifactId>mockito-junit-jupiter</artifactId>
-			<version>5.18.0</version>
+			<version>${mockito.version}</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.mockito</groupId>
 			<artifactId>mockito-core</artifactId>
-			<version>5.18.0</version>
+			<version>${mockito.version}</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
@@ -246,6 +247,11 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
 				<version>3.5.3</version>
+				<configuration>
+					<argLine>
+						-javaagent:${settings.localRepository}/org/mockito/mockito-core/${mockito.version}/mockito-core-${mockito.version}.jar
+					</argLine>
+				</configuration>
 			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
When running tests at the moment, this message is logged:

```
Mockito is currently self-attaching to enable the inline-mock-maker. This will no longer work in future releases of the JDK. Please add Mockito as an agent to your 
build as described in Mockito's documentation: https://javadoc.io/doc/org.mockito/mockito-core/latest/org.mockito/org/mockito/Mockito.html#0.3
```

This MR implements the change and removes the warning.