### PR TITLE
chore: disallow duplicate dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -380,6 +380,24 @@
 					</execution>
 				</executions>
 			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-enforcer-plugin</artifactId>
+				<version>3.5.0</version>
+				<executions>
+					<execution>
+						<id>enforce-no-duplicate-dependencies</id>
+						<goals>
+							<goal>enforce</goal>
+						</goals>
+						<configuration>
+							<rules>
+								<banDuplicatePomDependencyVersions />
+							</rules>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
 		</plugins>
 	</build>
 


### PR DESCRIPTION
This MR adds plugin configuration that will fail the build when a dependency is defined twice. Example output:

```
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE                                                              
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  1.372 s                                                       
[INFO] Finished at: 2025-06-18T06:29:41+01:00
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-enforcer-plugin:3.5.0:enforce (enforce-no-duplicate-dependencies) on project libyear-maven-plugin: 
[ERROR] Rule 0: org.apache.maven.enforcer.rules.BanDuplicatePomDependencyVersions failed with message:
[ERROR] Found 1 duplicate dependency declaration in this project:
[ERROR]  - dependencies.dependency[com.github.tomakehurst:wiremock-jre8:jar] (2 times)
```