### PR TITLE
chore(deps): move to newer Wiremock coordinates and upgrade

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -146,12 +146,12 @@
 		<dependency>
 			<groupId>org.apache.httpcomponents.client5</groupId>
 			<artifactId>httpclient5</artifactId>
-			<version>5.3.1</version>
+			<version>5.5</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.httpcomponents.core5</groupId>
 			<artifactId>httpcore5</artifactId>
-			<version>5.2.4</version>
+			<version>5.3.4</version>
 		</dependency>
 		<dependency>
 			<groupId>org.codehaus.plexus</groupId>
@@ -213,9 +213,9 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>com.github.tomakehurst</groupId>
-			<artifactId>wiremock-jre8</artifactId>
-			<version>2.35.2</version>
+			<groupId>org.wiremock</groupId>
+			<artifactId>wiremock</artifactId>
+			<version>3.13.1</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>


### PR DESCRIPTION
The Apache httpclient dependency upgrades are necessary. It seems wiremock is calling methods that don't exist in the older version that the project was using.