### PR TITLE
chore: remove transitive dependency version override

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -228,19 +228,6 @@
 		</dependency>
 	</dependencies>
 
-	<dependencyManagement>
-		<dependencies>
-			<dependency>
-				<!-- Currently we're using org.apache.httpcomponents:httpclient@4.5.14 
-					which depends on commons-codec:commons-codec, has a CVSS 3.7 vulerability. 
-					This section exists to remediate it -->
-				<groupId>commons-codec</groupId>
-				<artifactId>commons-codec</artifactId>
-				<version>1.18.0</version>
-			</dependency>
-		</dependencies>
-	</dependencyManagement>
-
 	<build>
 		<plugins>
 			<plugin>


### PR DESCRIPTION
commons-codec is no longer a transitive dependency, so this had no effect