### PR TITLE
fix: prevent errors when ${project.properties} is used inside <dependencyManagement />

### DIFF
--- a/src/it/version-uses-project.version-property/invoker.properties
+++ b/src/it/version-uses-project.version-property/invoker.properties
@@ -1,0 +1,1 @@
+invoker.goals.1=${project.groupId}:${project.artifactId}:${project.version}:analyze

--- a/src/it/version-uses-project.version-property/pom.xml
+++ b/src/it/version-uses-project.version-property/pom.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>localhost</groupId>
+  <artifactId>basic-single-dependency</artifactId>
+  <version>1.0</version>
+  <packaging>pom</packaging>
+  <name>libyear-report</name>
+
+  <description>Testing how the plugin interprets versions in Maven project properties</description>
+  <url>http://localhost/</url>
+
+  <!-- This bug only manifests when the project version is used in <dependencyManagement /> -->
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.apache.commons</groupId>
+        <artifactId>commons-text</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-text</artifactId>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/src/it/version-uses-project.version-property/verify.groovy
+++ b/src/it/version-uses-project.version-property/verify.groovy
@@ -1,0 +1,2 @@
+def buildLog = new File(basedir, "build.log")
+assert !buildLog.text.contains("Illegal character in query")

--- a/src/main/java/io/github/mfoo/libyear/LibYearMojo.java
+++ b/src/main/java/io/github/mfoo/libyear/LibYearMojo.java
@@ -779,6 +779,10 @@ public class LibYearMojo extends AbstractMojo {
 
     /** Make the API call to fetch the release date */
     private Optional<String> fetchReleaseDate(String groupId, String artifactId, String version) {
+        if (version.equals("${project.version}")) {
+            version = project.getVersion();
+        }
+
         URI artifactUri = URI.create(String.format(
                 "%s/solrsearch/select?q=g:%s+AND+a:%s+AND+v:%s&wt=json", SEARCH_URI, groupId, artifactId, version));
 


### PR DESCRIPTION
Currently the following is printed on the console:

```
[ERROR] Failed to fetch release date for org.apache.commons:commons-text ${project.version}: Illegal character in query at index 92: https://search.maven.org/solrsearch/select?q=g:org.apache.commons+AND+a:commons-text+AND+v:${project.version}&wt=json
```

This happens when we look up the dependencyManagement version by querying Maven, but we don't interpolate the variable. Properties defined in `<properties />` work, but not "magic" Maven versions.