### PR TITLE
chore: don't run commitlint on main

### DIFF
--- a/.github/workflows/commit-lint.yml
+++ b/.github/workflows/commit-lint.yml
@@ -1,7 +1,11 @@
 # Source: https://commitlint.js.org/guides/ci-setup.html
 name: Conventional Commit message linting
 
-on: [push, pull_request]
+on:
+  push:
+    branches-ignore:
+      - main
+  pull_request:
 
 permissions:
   contents: read


### PR DESCRIPTION
This is unnecessary since code can only enter main via an MR.